### PR TITLE
fix 404 and drawImage errors

### DIFF
--- a/sources/chargen.js
+++ b/sources/chargen.js
@@ -665,11 +665,10 @@ $(document).ready(function() {
   }
 
   function getImage2(imgRef, callback, layers, prevctx) {
-    if (images[imgRef]) {
+    if (imgRef && images[imgRef]) {
       callback(layers, prevctx);
       return images[imgRef];
-    } else {
-
+    } else if (imgRef) {
       var img = new Image();
       img.src = "spritesheets/" + imgRef;
       img.onload = function() { callback(layers, prevctx) };
@@ -709,11 +708,13 @@ $(document).ready(function() {
             }
           }
           try {
-            layers.forEach((layer) =>{
-              prevctx.drawImage(images[layer.link], previewColumn * universalFrameSize + previewXOffset, previewRow * universalFrameSize + previewYOffset, universalFrameSize, universalFrameSize, 0, 0, universalFrameSize, universalFrameSize);
+            layers.forEach((layer) => {
+              if (layer && layer.link) {
+                prevctx.drawImage(images[layer.link], previewColumn * universalFrameSize + previewXOffset, previewRow * universalFrameSize + previewYOffset, universalFrameSize, universalFrameSize, 0, 0, universalFrameSize, universalFrameSize);
+              }
             });
           } catch (err) {
-            console.log(err);
+            console.error(err);
           }
         };
 


### PR DESCRIPTION
Fixes:

- Attempting to fetch urls for images like: https://liberatedpixelcup.github.io/Universal-LPC-Spritesheet-Character-Generator/spritesheets/undefined

- Errors with message: InvalidStateError: Failed to execute 'drawImage' on 'CanvasRenderingContext2D': The HTMLImageElement provided is in the 'broken' state.