### PR TITLE
add button to remove assets incompatible with licenses

### DIFF
--- a/sources/source_index.html
+++ b/sources/source_index.html
@@ -73,6 +73,7 @@
 						<a href="https://www.gnu.org/licenses/gpl-3.0.en.html#license-text">Show license (3.0)</a>
 					</li>
 				</ul>
+				<button type="button" class="removeIncompatibleWithLicenses">Remove Assets Incompatible With Selected Licenses</button>
 			</div>
 		</div>
 		<section id="chooser">


### PR DESCRIPTION
Related Discussion: #50 

This adds a button to License filter section that will allow the user to remove any selected assets incompatible with licenses selected in the license filter.

~It will NOT remove the default selections if they are selected but incompatible. (But it will not select the defaults if they are not). Is this good?~