### PR TITLE
Fix item selection

### DIFF
--- a/sources/chargen.js
+++ b/sources/chargen.js
@@ -5,8 +5,6 @@ $.expr[':'].icontains = function(a, i, m) {
       .indexOf(m[3].toUpperCase()) >= 0;
 };
 
-$.fn.reverse = [].reverse;
-
 $(document).ready(function() {
 
   var matchBodyColor = true;
@@ -584,7 +582,7 @@ $(document).ready(function() {
   }
 
   function interpretParams() {
-    $("input[type=radio]").reverse().each(function() {
+    $("input[type=radio]").each(function() {
       var words = _.words($(this).attr('id'), '-');
       var initial = _.initial(words).join('-');
       $(this).prop("checked", $(this).attr("checked") || params[initial] == _.last(words));


### PR DESCRIPTION
Currently when you select anything, the body type switches back to "Male". When you then select "Female" for instance, it is not processed. Only after a second click it does process.

I don't know why this happens exactly, but I tracked it down to this change that was recently made. Reverting this fixes the issue.