### PR TITLE
alternate fix for jumping body-none

### DIFF
--- a/sources/chargen.js
+++ b/sources/chargen.js
@@ -582,10 +582,15 @@ $(document).ready(function() {
   }
 
   function interpretParams() {
+    const ids = new Set();
     $("input[type=radio]").each(function() {
-      var words = _.words($(this).attr('id'), '-');
-      var initial = _.initial(words).join('-');
-      $(this).prop("checked", $(this).attr("checked") || params[initial] == _.last(words));
+      const id = $(this).attr('id');
+      if (!ids.has(id)) {
+        ids.add(id);
+        const words = _.words($(this).attr('id'), '-');
+        const initial = _.initial(words).join('-');
+        $(this).prop("checked", $(this).attr("checked") || params[initial] === _.last(words));
+      }
     });
   }
 


### PR DESCRIPTION
Description of bug:

Select "No body" under body color. Hit Refresh. "Expand Selected" Expected result: "No body" next to "Body Color" is selected. Actual result: "No body" next to "Skeleton" is selected.

A better fix would be to ensure that no radio buttons have the same id.

This at least makes sure that the first such id gets selected instead of all of them in order, ending with the last.