### PR TITLE
Pinch to zoom in/out

### DIFF
--- a/sources/chargen.css
+++ b/sources/chargen.css
@@ -14,8 +14,16 @@ canvas {
   image-rendering: pixelated;
 }
 
-.zoomed {
+.zoomed-in {
   zoom: 2;
+}
+
+.zoomed-out {
+  zoom: 0.5;
+}
+
+.zoomed-in.zoomed-out {
+  zoom: 1;
 }
 
 body {

--- a/sources/chargen.js
+++ b/sources/chargen.js
@@ -374,8 +374,35 @@ $(document).ready(function () {
   }
 
   $("#spritesheet,#previewAnimations").on("click", function (e) {
-    $(this).toggleClass("zoomed");
+    $(this).toggleClass("zoomed-in");
   });
+  $("#spritesheet,#previewAnimations").on("dblclick", function (e) {
+    $(this).toggleClass("zoomed-out");
+  });
+
+  const spritesheetGesture = new TinyGesture(document.getElementById('spritesheet'), { mouseSupport: false });
+  const previewAnimationsGesture = new TinyGesture(document.getElementById('previewAnimations'), { mouseSupport: false });
+
+  spritesheetGesture.on('pinch', pinch.bind(spritesheetGesture));
+  previewAnimationsGesture.on('pinch', pinch.bind(previewAnimationsGesture));
+  spritesheetGesture.on('pinchend', pinchEnd);
+  previewAnimationsGesture.on('pinchend', pinchEnd);
+
+  let initialZoom = null;
+  function pinch(event) {
+    const scale = this.scale;
+    const $target = $(event.target);
+    if (initialZoom === null) {
+      initialZoom = $target.css('zoom') ?? 1;
+    }
+    $target.css('zoom', initialZoom * scale);
+    event.preventDefault();
+    event.stopImmediatePropagation();
+  }
+
+  function pinchEnd() {
+    initialZoom = null;
+  }
 
   function selectDefaults() {
     $(`#${"body-Body_color_light"}`).prop("checked", true);

--- a/sources/source_index.html
+++ b/sources/source_index.html
@@ -10,7 +10,14 @@
 	<script src="https://cdnjs.cloudflare.com/ajax/libs/underscore.string/2.4.0/underscore.string.min.js" integrity="sha512-EtNEjJOVcNyZFlf+g4ZhbYhyqBNBybgfUquvo5+gGSTTZBmm0+yJQXozIz/8qbzcdu0bWwdYQLBb5ROJqVB+Tw==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
 	<script type="text/javascript" src="sources/jhash-2.2.min.js"></script>
 	<script type="text/javascript" src="sources/custom-animations.js"></script>
-	<script type="text/javascript" src="sources/chargen.js?"></script>
+	<script type="module">
+		// make sure modern ESM library TinyGesture is loaded before chargen.js
+		import TinyGesture from 'https://cdn.jsdelivr.net/npm/tinygesture@3.0.0/+esm';
+		window.TinyGesture = TinyGesture;
+		const script = document.createElement('script');
+		script.src = 'sources/chargen.js';
+		document.body.appendChild(script);
+	</script>
 </head>
 <body>
 	<header>
@@ -48,7 +55,7 @@
 		</section>
 	</header>
 	<section id="preview">
-		<div class="instr">Complete sprite sheet (click to zoom): </div>
+		<div class="instr">Complete sprite sheet (click to zoom in, double click to zoom out): </div>
 		<canvas id="spritesheet" width="832" height="1344">HTML5 Browser required.</canvas>
 	</section>
 	<form id="customizeChar">


### PR DESCRIPTION
Partial implementation of #94

This allows you to

- double click to zoom out previewAnimations and spritesheet (click to zoom in still works).
- pinch to zoom in/out previewAnimations and spritesheet independently of viewport. (Pinching outside of those canvases zooms the whole page).
- tap or double tap emulates click / double click and can be used to quickly reset the zoom relative to viewport.

Note that the TinyGesture library uses passive listeners if supported by the browser as recommended by Google and other browser vendors. As a result, it is not going to be as smooth and responsive as a native app, however, it won't freeze and users are unlikely to see poor performance.