### PR TITLE
fix customize character previews extend beyond viewport width

### DIFF
--- a/sources/chargen.css
+++ b/sources/chargen.css
@@ -179,7 +179,7 @@ input[type=button], input[type=reset] {
   }
 
   #customizeChar > section {
-    width: calc(100% - 80px);
+    width: calc(100vw - 80px);
   }
 
   #chooser {


### PR DESCRIPTION
Fix for bug in #109

Before:

![Screenshot 2025-01-26 at 6 25 30 PM](https://github.com/user-attachments/assets/7e2ff980-1b94-49f4-b740-a43f9bdbbb8f)

After:

![Screenshot 2025-01-26 at 6 26 44 PM](https://github.com/user-attachments/assets/10311f3b-f428-4d89-9a0b-449c63125ec5)

