### PR TITLE
restore match_body-color checkbox

### DIFF
--- a/sources/source_index.html
+++ b/sources/source_index.html
@@ -79,6 +79,10 @@
 					<label class="control-label">Edit:</label>
 					<button type="button" id="resetAll">Reset all</button>
 					<button type="button" class="replacePinkMask">Replace Mask (pink)</button>
+					<label for="match_body-color">
+						<input type="checkbox" name="match_body-color" value="compact" id="match_body-color" checked>
+						Match body color
+					</label>
 				</div>
 				<div>
 					<label class="control-label">View:</label>


### PR DESCRIPTION
Code to make this work still exists in chargen.js but I'm not sure when this was deleted.