### PR TITLE
reduce size of index.html

### DIFF
--- a/scripts/generate_sources.js
+++ b/scripts/generate_sources.js
@@ -111,14 +111,15 @@ function parseJson(json) {
   }
 
   let startHTML =
-    `<li id="[ID_FOR]" class="variant-list" data-required="[REQUIRED_SEX]" data-animations="[SUPPORTED_ANIMATIONS]"><span class="condensed">${name}</span><ul>`
+    `<li id="[ID_FOR]" class="variant-list" data-required="[REQUIRED_SEX]" data-animations="[SUPPORTED_ANIMATIONS]" [DATA_FILE]><span class="condensed">${name}</span><ul>`
       .replace("[ID_FOR]", idFor)
       .replace("[REQUIRED_SEX]", requiredSex)
       .replace("[SUPPORTED_ANIMATIONS]", supportedAnimations);
 
   const endHTML = "</ul></li>";
   
-  let listCreditToUse = "";
+  let listCreditToUse = null;
+  let listDataFiles = "";
 
   const id = `${typeName}-none_${name.replaceAll(' ', '_')}`;
   let listItemsHTML = `<li class="excluded-hide"><input type="radio" id="${id}" name="${typeName}" class="none"> <label for="${id}">No ${typeName}</label></li><li class="excluded-text"></li>`;
@@ -181,7 +182,7 @@ function parseJson(json) {
           }
           if (creditToUse !== undefined) {
             // comparing via JSON.stringify is faster than node-deep-equal library
-            if (listCreditToUse === "" || JSON.stringify(listCreditToUse) !== JSON.stringify(creditToUse)) {
+            if (listCreditToUse === null || JSON.stringify(listCreditToUse) !== JSON.stringify(creditToUse)) {
               listCreditToUse = creditToUse
             }
             for (license in creditToUse.licenses) {
@@ -190,14 +191,14 @@ function parseJson(json) {
               }
             }
             const licenses = '"' + creditToUse.licenses.join(",") + '" ';
-            dataFiles += `data-layer_${jdx}_${sex}_licenses=${licenses} `;
+            // dataFiles += `data-layer_${jdx}_${sex}_licenses=${licenses} `;
             const authors = '"' + creditToUse.authors.join(",") + '" ';
-            dataFiles += `data-layer_${jdx}_${sex}_authors=${authors} `;
+            // dataFiles += `data-layer_${jdx}_${sex}_authors=${authors} `;
             const urls = '"' + creditToUse.urls.join(",") + '" ';
-            dataFiles += `data-layer_${jdx}_${sex}_urls=${urls} `;
+            // dataFiles += `data-layer_${jdx}_${sex}_urls=${urls} `;
             const notes =
               '"' + creditToUse.notes.replaceAll('"', "**") + '" ';
-            dataFiles += `data-layer_${jdx}_${sex}_notes=${notes} `;
+            // dataFiles += `data-layer_${jdx}_${sex}_notes=${notes} `;
             if (!addedCreditsFor.includes(imageFileName)) {
               const quotedShortName = '"' + file + variant + '.png"';
               listItemsCSV += `${quotedShortName},${notes},${authors},${licenses},${urls}\n`;
@@ -218,6 +219,20 @@ function parseJson(json) {
       .replaceAll("[VARIANT]", variant)
       .replaceAll("[DATA_FILE]", dataFiles);
   } // for variant
+
+  for (const sex of requiredSexes) {
+    const licenses = '"' + listCreditToUse.licenses.join(",") + '" ';
+    listDataFiles += `data-${sex}_licenses=${licenses} `;
+    const authors = '"' + listCreditToUse.authors.join(",") + '" ';
+    listDataFiles += `data-${sex}_authors=${authors} `;
+    const urls = '"' + listCreditToUse.urls.join(",") + '" ';
+    listDataFiles += `data-${sex}_urls=${urls} `;
+    const notes =
+      '"' + listCreditToUse.notes.replaceAll('"', "**") + '" ';
+    listDataFiles += `data-${sex}_notes=${notes} `;
+  }
+  startHTML = startHTML.replaceAll("[DATA_FILE]", listDataFiles);
+
   const html = startHTML + listItemsHTML + endHTML;
   let parsed = {};
   parsed.html = html;

--- a/scripts/generate_sources.js
+++ b/scripts/generate_sources.js
@@ -118,6 +118,7 @@ function parseJson(json) {
 
   const endHTML = "</ul></li>";
   
+  let canUseListCredits = true;
   let listCreditToUse = null;
   let listDataFiles = "";
 
@@ -182,8 +183,12 @@ function parseJson(json) {
           }
           if (creditToUse !== undefined) {
             // comparing via JSON.stringify is faster than node-deep-equal library
-            if (listCreditToUse === null || JSON.stringify(listCreditToUse) !== JSON.stringify(creditToUse)) {
-              listCreditToUse = creditToUse
+            if (listCreditToUse !== null &&
+                JSON.stringify(listCreditToUse) !== JSON.stringify(creditToUse))
+            {
+              canUseListCredits = false;
+            } else if (listCreditToUse === null) {
+              listCreditToUse = creditToUse;
             }
             for (license in creditToUse.licenses) {
               if (!licensesFound.includes(license)) {
@@ -191,14 +196,16 @@ function parseJson(json) {
               }
             }
             const licenses = '"' + creditToUse.licenses.join(",") + '" ';
-            // dataFiles += `data-layer_${jdx}_${sex}_licenses=${licenses} `;
             const authors = '"' + creditToUse.authors.join(",") + '" ';
-            // dataFiles += `data-layer_${jdx}_${sex}_authors=${authors} `;
             const urls = '"' + creditToUse.urls.join(",") + '" ';
-            // dataFiles += `data-layer_${jdx}_${sex}_urls=${urls} `;
             const notes =
               '"' + creditToUse.notes.replaceAll('"', "**") + '" ';
-            // dataFiles += `data-layer_${jdx}_${sex}_notes=${notes} `;
+            if (!canUseListCredits) {
+              dataFiles += `data-layer_${jdx}_${sex}_licenses=${licenses} `;
+              dataFiles += `data-layer_${jdx}_${sex}_authors=${authors} `;
+              dataFiles += `data-layer_${jdx}_${sex}_urls=${urls} `;
+              dataFiles += `data-layer_${jdx}_${sex}_notes=${notes} `;
+            }
             if (!addedCreditsFor.includes(imageFileName)) {
               const quotedShortName = '"' + file + variant + '.png"';
               listItemsCSV += `${quotedShortName},${notes},${authors},${licenses},${urls}\n`;

--- a/scripts/template-general.html
+++ b/scripts/template-general.html
@@ -1,6 +1,6 @@
 <li>
   <label for="[ID_FOR]">
-    <input type="radio" id="[ID_FOR]" name="[TYPE_NAME]" parentName="[PARENT_NAME]" variant="[VARIANT]" matchBodyColor="[MATCH_BODY_COLOR]" [DATA_FILE] [CHECKED]>
+    <input type="radio" id="[ID_FOR]" name="[TYPE_NAME]" parentName="[PARENT_NAME]" variant="[VARIANT]" matchBodyColor="[MATCH_BODY_COLOR]" [DATA_FILE]>
     <span>[NAME]</span>
   </label>
 </li>

--- a/sources/chargen.js
+++ b/sources/chargen.js
@@ -109,7 +109,7 @@ $(document).ready(function () {
   nextFrame();
 
   // set params and redraw when any radio button is clicked on
-  $("input[type=radio]").each(function () {
+  $("#chooser input[type=radio]").each(function () {
     $(this).click(function () {
       if (matchBodyColor) {
         matchBodyColorForThisAsset = $(this).attr("matchBodyColor");
@@ -239,12 +239,16 @@ $(document).ready(function () {
 
   $(".removeIncompatibleWithLicenses").click(function () {
     const allowedLicenses = getAllowedLicenses();
+    const bodyTypeName = getBodyTypeName();
     $("#chooser li.variant").each(function () {
       const $this = $(this);
-      const licenses = $this.data(`${getBodyTypeName()}_licenses`);
+      let licenses = $this.data(`${bodyTypeName}_licenses`);
       $this.find("input[type=radio]").each(function () {
         const $parent = $this;
         const $el = $(this);
+        // check if variant specific license; otherwise fall back to list licenses
+        licenses = $(this).data(`layer_1_${bodyTypeName}_licenses`) || licenses;
+
         // Toggle allowed licenses
         if (licenses !== undefined) {
           const licensesForAsset = licenses.split(",");
@@ -268,7 +272,7 @@ $(document).ready(function () {
 
   $(".removeUnsupported").click(function () {
     const selectedAnims = getSelectedAnimations();
-    $("input[type=radio]").each(function () {
+    $("#chooser input[type=radio]").each(function () {
       const $li = $(this).closest("li[data-animations]");
       if ($li.data("animations") && selectedAnims.length > 0) {
         const requiredAnimations = $li.data("animations").split(",");
@@ -646,7 +650,7 @@ $(document).ready(function () {
     };
 
     zPosition = 0;
-    $("input[type=radio]:checked").each(function (index) {
+    $("#chooser input[type=radio]:checked").each(function (index) {
       const $this = $(this);
       for (jdx = 1; jdx < 10; jdx++) {
         const bodyTypeKey = `layer_${jdx}_${bodyTypeName}`;
@@ -658,10 +662,10 @@ $(document).ready(function () {
           const name = $this.attr(`parentName`);
           const variant = $this.attr(`variant`);
           const $liVariant = $this.closest("li.variant");
-          const licenses = $liVariant.data(`${bodyTypeName}_licenses`);
-          const authors = $liVariant.data(`${bodyTypeName}_authors`);
-          const urls = $liVariant.data(`${bodyTypeName}_urls`);
-          const notes = $liVariant.data(`${bodyTypeName}_notes`);
+          const licenses = $this.data(`${bodyTypeKey}_licenses`) || $liVariant.data(`${bodyTypeName}_licenses`);
+          const authors = $this.data(`${bodyTypeKey}_authors`) || $liVariant.data(`${bodyTypeName}_authors`);
+          const urls = $this.data(`${bodyTypeKey}_urls`) || $liVariant.data(`${bodyTypeName}_urls`);
+          const notes = $this.data(`${bodyTypeKey}_notes`) || $liVariant.data(`${bodyTypeName}_notes`);
 
           if (fileName !== "") {
             const supportedAnimations = $this
@@ -888,7 +892,7 @@ $(document).ready(function () {
 
     // only interested in tags if on a selected item
     const selectedTags = new Set();
-    $("input[type=radio]:checked").each(function () {
+    $("#chooser input[type=radio]:checked").each(function () {
       const tags = $(this).data("tags");
       tags && tags.split(",").forEach(tag =>
         selectedTags.add(tag)
@@ -1016,9 +1020,10 @@ $(document).ready(function () {
       let display = true;
 
       // Toggle allowed licenses
-      const licenses = $this
-        .closest("li.variant")
-        .data(`${getBodyTypeName()}_licenses`);
+      const bodyTypeName = getBodyTypeName();
+      const licenses =
+        $this.data(`layer_1_${bodyTypeName}_licenses`) ||
+        $this.closest("li.variant").data(`${bodyTypeName}_licenses`);
       if (licenses !== undefined) {
         const licensesForAsset = licenses.split(",");
         if (
@@ -1080,18 +1085,18 @@ $(document).ready(function () {
   }
 
   function interpretParams() {
-    $("input[type=radio]").each(function () {
+    $("#chooser input[type=radio]").each(function () {
       const words = $(this).attr("id").split("-");
       const initial = words[0];
       $(this).prop(
         "checked",
-        $(this).attr("checked") || params[initial] == words[1]
+        $(this).attr("checked") || params[initial] === words[1]
       );
     });
   }
 
   function setParams() {
-    $("input[type=radio]:checked").each(function () {
+    $("#chooser input[type=radio]:checked").each(function () {
       const words = $(this).attr("id").split("-");
       const initial = words[0];
       if (!$(this).attr("checked") || params[initial]) {

--- a/sources/chargen.js
+++ b/sources/chargen.js
@@ -239,22 +239,27 @@ $(document).ready(function () {
 
   $(".removeIncompatibleWithLicenses").click(function () {
     const allowedLicenses = getAllowedLicenses();
-    $("input[type=radio]").each(function () {
-      // Toggle allowed licenses
-      const licenses = $(this).data(`layer_1_${getBodyTypeName()}_licenses`);
-      if (licenses !== undefined) {
-        const licensesForAsset = licenses.split(",");
-        if (
-          !allowedLicenses.some((allowedLicense) =>
-            licensesForAsset.includes(allowedLicense)
-          )
-        ) {
-          if ($(this).prop("checked")) {
-            $(this).attr("checked", false).prop("checked", false);
-            $(this).closest("ul").find("input[type=radio][id*=none]").click();
+    $("#chooser li.variant").each(function () {
+      const $this = $(this);
+      const licenses = $this.data(`${getBodyTypeName()}_licenses`);
+      $this.find("input[type=radio]").each(function () {
+        const $parent = $this;
+        const $el = $(this);
+        // Toggle allowed licenses
+        if (licenses !== undefined) {
+          const licensesForAsset = licenses.split(",");
+          if (
+            !allowedLicenses.some((allowedLicense) =>
+              licensesForAsset.includes(allowedLicense)
+            )
+          ) {
+            if ($el.prop("checked")) {
+              $el.attr("checked", false).prop("checked", false);
+              $parent.find("input[type=radio][id*=none]").click();
+            }
           }
         }
-      }
+      });
     });
     setParams();
     redraw();
@@ -652,10 +657,11 @@ $(document).ready(function () {
           const parentName = $this.attr(`name`);
           const name = $this.attr(`parentName`);
           const variant = $this.attr(`variant`);
-          const licenses = $this.data(`${bodyTypeKey}_licenses`);
-          const authors = $this.data(`${bodyTypeKey}_authors`);
-          const urls = $this.data(`${bodyTypeKey}_urls`);
-          const notes = $this.data(`${bodyTypeKey}_notes`);
+          const $liVariant = $this.closest("li.variant");
+          const licenses = $liVariant.data(`${bodyTypeName}_licenses`);
+          const authors = $liVariant.data(`${bodyTypeName}_authors`);
+          const urls = $liVariant.data(`${bodyTypeName}_urls`);
+          const notes = $liVariant.data(`${bodyTypeName}_notes`);
 
           if (fileName !== "") {
             const supportedAnimations = $this
@@ -1010,7 +1016,9 @@ $(document).ready(function () {
       let display = true;
 
       // Toggle allowed licenses
-      const licenses = $this.data(`layer_1_${getBodyTypeName()}_licenses`);
+      const licenses = $this
+        .closest("li.variant")
+        .data(`${getBodyTypeName()}_licenses`);
       if (licenses !== undefined) {
         const licensesForAsset = licenses.split(",");
         if (

--- a/sources/chargen.js
+++ b/sources/chargen.js
@@ -240,7 +240,7 @@ $(document).ready(function () {
   $(".removeIncompatibleWithLicenses").click(function () {
     const allowedLicenses = getAllowedLicenses();
     const bodyTypeName = getBodyTypeName();
-    $("#chooser li.variant").each(function () {
+    $("#chooser li.variant-list").each(function () {
       const $this = $(this);
       let licenses = $this.data(`${bodyTypeName}_licenses`);
       $this.find("input[type=radio]").each(function () {
@@ -325,7 +325,7 @@ $(document).ready(function () {
     document.body.appendChild(a);
     a.innerHTML = "dummyhtml";
     a.click();
-    document.removeChild(a);
+    document.body.removeChild(a);
   });
 
   $(".importFromClipboard").click(async function () {
@@ -655,13 +655,13 @@ $(document).ready(function () {
       for (jdx = 1; jdx < 10; jdx++) {
         const bodyTypeKey = `layer_${jdx}_${bodyTypeName}`;
         if ($this.data(bodyTypeKey)) {
+          const $liVariant = $this.closest("li.variant-list");
           const zPos = $this.data(`layer_${jdx}_zpos`);
           const custom_animation = $this.data(`layer_${jdx}_custom_animation`);
-          const fileName = $this.data(bodyTypeKey);
+          const fileName = $this.data(bodyTypeKey) || $liVariant.data();
           const parentName = $this.attr(`name`);
           const name = $this.attr(`parentName`);
           const variant = $this.attr(`variant`);
-          const $liVariant = $this.closest("li.variant");
           const licenses = $this.data(`${bodyTypeKey}_licenses`) || $liVariant.data(`${bodyTypeName}_licenses`);
           const authors = $this.data(`${bodyTypeKey}_authors`) || $liVariant.data(`${bodyTypeName}_authors`);
           const urls = $this.data(`${bodyTypeKey}_urls`) || $liVariant.data(`${bodyTypeName}_urls`);
@@ -1023,7 +1023,7 @@ $(document).ready(function () {
       const bodyTypeName = getBodyTypeName();
       const licenses =
         $this.data(`layer_1_${bodyTypeName}_licenses`) ||
-        $this.closest("li.variant").data(`${bodyTypeName}_licenses`);
+        $this.closest("li.variant-list").data(`${bodyTypeName}_licenses`);
       if (licenses !== undefined) {
         const licensesForAsset = licenses.split(",");
         if (


### PR DESCRIPTION
If we could asuume that credit info such as licenses, notes, and authors are the same for all layers and variants rather than specific to every image file, we could have reduced the size of index.html by about 88%, from 105 MB to 12 MB

After implementing a fallback to the current method in cases where variants or layers have different licenses, notes, or authors, the size increased a bit back to about 15MB. That is still a 85% decrease.

```
$ git show master -- index.html | wc -c
 105354845
$ git show HEAD~1 -- index.html | wc -c
 12486407
$ cat index.html | wc -c
 14699804
```
