### PR TITLE
prevent invalid state error

### DIFF
--- a/sources/chargen.js
+++ b/sources/chargen.js
@@ -1774,6 +1774,11 @@ $(".exportSplitAnimations").click(async function() {
       img.addEventListener("load", function () {
         callback(layers, prevctx);
       });
+      img.addEventListener("error", function (event) {
+        if (DEBUG)
+          console.error("There was an error loading image:", event.target.src);
+        images[imgRef] = null;
+      });
       return img;
     }
   }


### PR DESCRIPTION
Partial fix for #201 

This just makes the generator recover more gracefully so that you don't see that completely blank canvas if just one image didn't load.

Does:

- Prevents drawing an image to a canvas if it was broken, i.e. '404 not found'
- Prevents drawing an incomplete preview in left column if one of the layers is broken.
- In debug mode (add &debug=true) it prints out an error to the console when an image errors.

Does not:

- Fix the actual issue that we are looking for an image that isn't there.