### PR TITLE
Fix collision of exported item animation filenames

### DIFF
--- a/sources/chargen.js
+++ b/sources/chargen.js
@@ -792,8 +792,7 @@ $(".exportSplitAnimations").click(async function() {
 });
 
   const getItemFileName = (item) =>
-    `${item.zPos}`.padStart(3, '0')
-      + ` ${item.parentName} ${item.name} ${item.variant}.png`;
+    `${item.zPos}`.padStart(3, '0') + ` ${item.fileName.replace(/\//g, ' ')}`;
 
   function reportFailedItemAnimations(failedStandard, failedCustom) {
     const numFailedStandard = Object.keys(failedStandard).length;


### PR DESCRIPTION
Base item animation filenames upon spritesheet filenames, since item spritesheets can have identical parentName/name/variant (such as foreground and background sheets for the same item)