### PR TITLE
feat: Preload assets to speed up page load

### DIFF
--- a/sources/source_index.html
+++ b/sources/source_index.html
@@ -4,6 +4,13 @@
 	<meta charset="utf-8">
 	<meta http-equiv="X-UA-Compatible" content="IE=Edge,chrome=1">
 	<title>Universal LPC Sprite Sheet Character Generator</title>
+	<!-- Preconnect for faster resource loading from external CDNs -->
+	<link rel="preconnect" href="https://code.jquery.com" crossorigin>
+	<link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
+	<!-- Preload critical resources -->
+	<link rel="preload" href="sources/chargen.css" as="style">
+	<link rel="preload" href="https://code.jquery.com/jquery-3.7.1.min.js" as="script" crossorigin integrity="sha256-/JqT3SQfawRcv/BIHPThkBvs0OEvtFFmqPF/lYI/Cxo=">
+	<link rel="preload" href="sources/chargen.js" as="script">
 	<link rel="stylesheet" type="text/css" href="sources/chargen.css">
 	<script src="https://code.jquery.com/jquery-3.7.1.min.js" integrity="sha256-/JqT3SQfawRcv/BIHPThkBvs0OEvtFFmqPF/lYI/Cxo=" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
 	<script type="text/javascript" src="sources/jhash-2.2.min.js"></script>


### PR DESCRIPTION
Small PR to force preload of js, should speed up page ready a bit.
According to the profiler:
With:
<img width="365" height="165" alt="image" src="https://github.com/user-attachments/assets/4d1b192a-aea2-4d3a-862b-93ac28056c63" />

Without:
<img width="282" height="131" alt="image" src="https://github.com/user-attachments/assets/ad167248-4693-491b-a49f-37236f5ac48e" />

To try locally, just load the page and run in the console: `performance.getEntriesByName('invoke-page-ready')`

In netlify vs example in docs:

netlify (with):
<img width="285" height="161" alt="image" src="https://github.com/user-attachments/assets/c7a1079d-fca2-4012-947d-b184459951ec" />

docs (without):
<img width="282" height="160" alt="image" src="https://github.com/user-attachments/assets/523ee6fb-e963-4dcd-a470-90a4dcdbfbb0" />

Not the most dramatical improvement, but hopefully everything will compound :)