### PR TITLE
feat: Re-enable any part to change the body parts color

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,5 @@
+root = true
+
+[*.js]
+indent_style = tab
+indent_size = 4

--- a/sources/components/tree/CategoryTree.js
+++ b/sources/components/tree/CategoryTree.js
@@ -55,7 +55,12 @@ export const CategoryTree = {
 							state.matchBodyColorEnabled = e.target.checked;
 							// If enabling the checkbox, immediately apply match body color
 							if (e.target.checked) {
-								applyMatchBodyColor();
+								// Use body-body as the source if available
+								const bodySelectionGroup = getSelectionGroup('body-body');
+								const bodySelection = state.selections[bodySelectionGroup];
+								if (bodySelection?.variant) {
+									applyMatchBodyColor(bodySelection.variant);
+								}
 							}
 						}
 					}),

--- a/sources/components/tree/ItemWithVariants.js
+++ b/sources/components/tree/ItemWithVariants.js
@@ -84,9 +84,9 @@ export const ItemWithVariants = {
 									name: `${displayName} (${variantDisplayName})`
 								};
 
-								// If this is the body color, apply match body color to other items
-								if (itemId === 'body-body') {
-									applyMatchBodyColor();
+								// If this item has matchBodyColor enabled, apply to all other body-colored items
+								if (meta.matchBodyColor) {
+									applyMatchBodyColor(variant);
 								}
 							}
 						}

--- a/sources/state/state.js
+++ b/sources/state/state.js
@@ -163,37 +163,27 @@ export function resetAll() {
 	m.redraw();
 }
 
-// Apply match body color - when body color changes, update all items with matchBodyColor: true
-export function applyMatchBodyColor() {
+// Apply match body color - when any body-colored part changes, update all items with matchBodyColor: true
+export function applyMatchBodyColor(variantToMatch) {
 	// Only apply if feature is enabled
 	if (!state.matchBodyColorEnabled) return;
 
-	// Get the current body selection
-	const bodySelectionGroup = getSelectionGroup('body-body');
-	const bodySelection = state.selections[bodySelectionGroup];
-
-	// If no body selected, nothing to match
-	if (!bodySelection) return;
-
-	const bodyVariant = bodySelection.variant;
-	if (!bodyVariant) return;
+	// If no variant specified, nothing to match
+	if (!variantToMatch) return;
 
 	// Update all selected items that have matchBodyColor: true
 	for (const [selectionGroup, selection] of Object.entries(state.selections)) {
-		// Skip the body itself
-		if (selectionGroup === bodySelectionGroup) continue;
-
 		const itemId = selection.itemId;
 		const meta = window.itemMetadata?.[itemId];
 
 		// Skip if no metadata or matchBodyColor is not enabled for this item
 		if (!meta || !meta.matchBodyColor) continue;
 
-		// Check if this item has the body variant available
-		if (meta.variants && meta.variants.includes(bodyVariant)) {
-			// Update the variant to match the body
-			selection.variant = bodyVariant;
-			selection.name = meta.name + ` (${bodyVariant})`;
+		// Check if this item has the variant available
+		if (meta.variants && meta.variants.includes(variantToMatch)) {
+			// Update the variant to match
+			selection.variant = variantToMatch;
+			selection.name = meta.name + ` (${variantToMatch})`;
 		}
 	}
 }


### PR DESCRIPTION
Fixes the issue where everything matched the body color. Now any part changes the whole set's color to match. If it is checked directly, it changes to whatever the body color is.

Also added an .editorconfig so it stops breaking the format every time (it's annoying to read through the noise).