### PR TITLE
fix: split NameAndVariant correctly for variants with underscores

### DIFF
--- a/sources/canvas/load-image.js
+++ b/sources/canvas/load-image.js
@@ -52,7 +52,9 @@ export async function loadImagesInParallel(items, getPath = (item) => item.sprit
     loadImage(getPath(item))
       .then(img => ({ item, img, success: true }))
       .catch(err => {
-        console.warn(`Failed to load sprite: ${getPath(item)}`);
+        if (window.DEBUG) {
+          console.warn(`Failed to load sprite: ${getPath(item)}`);
+        }
         return { item, img: null, success: false };
       })
   );

--- a/sources/canvas/renderer.js
+++ b/sources/canvas/renderer.js
@@ -269,7 +269,9 @@ export async function renderCharacter(selections, bodyType, targetCanvas = null)
         return loadImage(item.spritePath)
           .then(img => ({ item, img, success: true }))
           .catch(err => {
-            console.warn(`Failed to load sprite: ${item.spritePath}`);
+            if (window.DEBUG) {
+				console.warn(`Failed to load sprite: ${item.spritePath}`);
+            }
             return { item, img: null, success: false };
           });
       }

--- a/sources/state/state.js
+++ b/sources/state/state.js
@@ -70,7 +70,7 @@ export async function selectDefaults() {
 	// Update URL hash
 	syncSelectionsToHash();
 
-	await renderer.renderCharacter(state.selections, state.bodyType);
+	await renderCharacter(state.selections, state.bodyType);
 
 	// Trigger redraw to update preview canvas after offscreen render completes
 	m.redraw();


### PR DESCRIPTION
See comments in source on new getNameWithoutVariant helper

I noticed this issue while testing for #263 , but its actually separate.