### PR TITLE
Fix Body Color expands or collapses with Body

### DIFF
--- a/sources/components/tree/ItemWithVariants.js
+++ b/sources/components/tree/ItemWithVariants.js
@@ -6,16 +6,20 @@ import { variantToFilename, capitalize } from '../../utils/helpers.js';
 export const ItemWithVariants = {
 	view: function(vnode) {
 		const { itemId, meta, isSearchMatch } = vnode.attrs;
-		const isExpanded = state.expandedNodes[itemId] || false;
 		const compactDisplay = state.compactDisplay;
 		const displayName = meta.name;
+		let nodePath = itemId;
+		if (displayName === 'Body color') {
+			nodePath = 'body-body';
+		}
+		const isExpanded = state.expandedNodes[nodePath] || false;
 
 		return m("div", {
 			class: isSearchMatch ? "search-result" : ""
 		}, [
 			m("div.tree-label", {
 				onclick: () => {
-					state.expandedNodes[itemId] = !isExpanded;
+					state.expandedNodes[nodePath] = !isExpanded;
 				}
 			}, [
 				m("span.tree-arrow", { class: isExpanded ? 'expanded' : 'collapsed' }),


### PR DESCRIPTION
"Body Color" and "Body" have the same itemId ("body") but different paths so they are shown as separate categories in the tree ("body" vs "body-body") but they expand or collapse at the same time.

This is a quick and dirty fix for this bug.

@cdvv7788 may be able to suggest something better.