### PR TITLE
* Issue #275 Added Custom Animations to Filters List

### DIFF
--- a/item-metadata.js
+++ b/item-metadata.js
@@ -1255,13 +1255,7 @@ window.itemMetadata = {
       "pregnant"
     ],
     "animations": [
-      "spellcast",
-      "thrust",
-      "walk",
-      "slash",
-      "shoot",
-      "hurt",
-      "watering"
+      "wheelchair"
     ],
     "tags": [],
     "required_tags": [],
@@ -65475,7 +65469,9 @@ window.itemMetadata = {
       "muscular",
       "pregnant"
     ],
-    "animations": [],
+    "animations": [
+      "tool_rod"
+    ],
     "tags": [],
     "required_tags": [],
     "excluded_tags": [],
@@ -65560,7 +65556,8 @@ window.itemMetadata = {
       "pregnant"
     ],
     "animations": [
-      "walk"
+      "walk",
+      "slash_128"
     ],
     "tags": [],
     "required_tags": [],
@@ -65742,7 +65739,9 @@ window.itemMetadata = {
       "muscular",
       "pregnant"
     ],
-    "animations": [],
+    "animations": [
+      "tool_whip"
+    ],
     "tags": [],
     "required_tags": [],
     "excluded_tags": [],
@@ -73768,7 +73767,9 @@ window.itemMetadata = {
       "muscular",
       "pregnant"
     ],
-    "animations": [],
+    "animations": [
+      "slash_reverse_oversize"
+    ],
     "tags": [],
     "required_tags": [],
     "excluded_tags": [],
@@ -73935,7 +73936,8 @@ window.itemMetadata = {
     "animations": [
       "walk",
       "shoot",
-      "hurt"
+      "hurt",
+      "walk_128"
     ],
     "tags": [],
     "required_tags": [],
@@ -74052,7 +74054,8 @@ window.itemMetadata = {
     "animations": [
       "walk",
       "shoot",
-      "hurt"
+      "hurt",
+      "walk_128"
     ],
     "tags": [],
     "required_tags": [],
@@ -74179,7 +74182,8 @@ window.itemMetadata = {
     "animations": [
       "walk",
       "shoot",
-      "hurt"
+      "hurt",
+      "walk_128"
     ],
     "tags": [],
     "required_tags": [],
@@ -74385,7 +74389,8 @@ window.itemMetadata = {
     ],
     "animations": [
       "walk",
-      "hurt"
+      "hurt",
+      "slash_oversize"
     ],
     "tags": [],
     "required_tags": [],
@@ -74487,7 +74492,10 @@ window.itemMetadata = {
     ],
     "animations": [
       "walk",
-      "hurt"
+      "hurt",
+      "slash_oversize",
+      "slash_reverse_oversize",
+      "thrust_oversize"
     ],
     "tags": [],
     "required_tags": [],
@@ -74618,7 +74626,8 @@ window.itemMetadata = {
     ],
     "animations": [
       "walk",
-      "hurt"
+      "hurt",
+      "slash_oversize"
     ],
     "tags": [],
     "required_tags": [],
@@ -74717,7 +74726,8 @@ window.itemMetadata = {
     ],
     "animations": [
       "walk",
-      "hurt"
+      "hurt",
+      "slash_oversize"
     ],
     "tags": [],
     "required_tags": [],
@@ -74813,7 +74823,9 @@ window.itemMetadata = {
     ],
     "animations": [
       "walk",
-      "hurt"
+      "hurt",
+      "walk_128",
+      "slash_128"
     ],
     "tags": [],
     "required_tags": [],
@@ -74906,7 +74918,9 @@ window.itemMetadata = {
       "pregnant"
     ],
     "animations": [
-      "walk"
+      "walk",
+      "walk_128",
+      "slash_128"
     ],
     "tags": [],
     "required_tags": [],
@@ -74998,7 +75012,10 @@ window.itemMetadata = {
       "muscular",
       "pregnant"
     ],
-    "animations": [],
+    "animations": [
+      "walk_128",
+      "slash_128"
+    ],
     "tags": [],
     "required_tags": [],
     "excluded_tags": [],
@@ -75094,7 +75111,10 @@ window.itemMetadata = {
       "walk",
       "hurt",
       "idle",
-      "combat"
+      "combat",
+      "slash_128",
+      "backslash_128",
+      "halfslash_128"
     ],
     "tags": [],
     "required_tags": [],
@@ -75237,7 +75257,8 @@ window.itemMetadata = {
     ],
     "animations": [
       "walk",
-      "hurt"
+      "hurt",
+      "slash_oversize"
     ],
     "tags": [],
     "required_tags": [],
@@ -75336,7 +75357,8 @@ window.itemMetadata = {
     ],
     "animations": [
       "walk",
-      "hurt"
+      "hurt",
+      "slash_oversize"
     ],
     "tags": [],
     "required_tags": [],
@@ -75435,7 +75457,8 @@ window.itemMetadata = {
     ],
     "animations": [
       "walk",
-      "hurt"
+      "hurt",
+      "slash_oversize"
     ],
     "tags": [],
     "required_tags": [],
@@ -75532,7 +75555,9 @@ window.itemMetadata = {
       "muscular",
       "pregnant"
     ],
-    "animations": [],
+    "animations": [
+      "slash_reverse_oversize"
+    ],
     "tags": [],
     "required_tags": [],
     "excluded_tags": [],
@@ -75790,7 +75815,8 @@ window.itemMetadata = {
     ],
     "animations": [
       "walk",
-      "hurt"
+      "hurt",
+      "slash_oversize"
     ],
     "tags": [],
     "required_tags": [],
@@ -75882,7 +75908,9 @@ window.itemMetadata = {
     ],
     "animations": [
       "walk",
-      "hurt"
+      "hurt",
+      "thrust_oversize",
+      "slash_oversize"
     ],
     "tags": [],
     "required_tags": [],
@@ -75996,7 +76024,10 @@ window.itemMetadata = {
       "muscular",
       "pregnant"
     ],
-    "animations": [],
+    "animations": [
+      "walk_128",
+      "thrust_oversize"
+    ],
     "tags": [],
     "required_tags": [],
     "excluded_tags": [],
@@ -76108,7 +76139,10 @@ window.itemMetadata = {
       "muscular",
       "pregnant"
     ],
-    "animations": [],
+    "animations": [
+      "walk_128",
+      "thrust_oversize"
+    ],
     "tags": [],
     "required_tags": [],
     "excluded_tags": [],
@@ -76221,7 +76255,10 @@ window.itemMetadata = {
       "muscular",
       "pregnant"
     ],
-    "animations": [],
+    "animations": [
+      "walk_128",
+      "thrust_oversize"
+    ],
     "tags": [],
     "required_tags": [],
     "excluded_tags": [],
@@ -76421,7 +76458,8 @@ window.itemMetadata = {
     ],
     "animations": [
       "walk",
-      "hurt"
+      "hurt",
+      "thrust_oversize"
     ],
     "tags": [],
     "required_tags": [],
@@ -76544,7 +76582,8 @@ window.itemMetadata = {
     ],
     "animations": [
       "walk",
-      "hurt"
+      "hurt",
+      "thrust_oversize"
     ],
     "tags": [],
     "required_tags": [],
@@ -76667,7 +76706,8 @@ window.itemMetadata = {
     ],
     "animations": [
       "walk",
-      "hurt"
+      "hurt",
+      "thrust_oversize"
     ],
     "tags": [],
     "required_tags": [],
@@ -76790,7 +76830,8 @@ window.itemMetadata = {
     ],
     "animations": [
       "walk",
-      "hurt"
+      "hurt",
+      "thrust_oversize"
     ],
     "tags": [],
     "required_tags": [],
@@ -76904,7 +76945,8 @@ window.itemMetadata = {
     ],
     "animations": [
       "walk",
-      "hurt"
+      "hurt",
+      "thrust_oversize"
     ],
     "tags": [],
     "required_tags": [],

--- a/sheet_definitions/tool_rod.json
+++ b/sheet_definitions/tool_rod.json
@@ -25,7 +25,9 @@
   "variants": [
     "rod"
   ],
-  "animations": [],
+  "animations": [
+    "tool_rod"
+  ],
   "credits": [
     {
       "file": "tools/rod",

--- a/sheet_definitions/tool_smash.json
+++ b/sheet_definitions/tool_smash.json
@@ -32,7 +32,8 @@
     "pickaxe"
   ],
   "animations": [
-    "walk"
+    "walk",
+    "slash_128"
   ],
   "credits": [
     {

--- a/sheet_definitions/tool_whip.json
+++ b/sheet_definitions/tool_whip.json
@@ -25,7 +25,9 @@
   "variants": [
     "whip"
   ],
-  "animations": [],
+  "animations": [
+    "tool_whip"
+  ],
   "credits": [
     {
       "file": "tools/whip",

--- a/sheet_definitions/weapon_blunt_club.json
+++ b/sheet_definitions/weapon_blunt_club.json
@@ -23,7 +23,9 @@
   "variants": [
     "club"
   ],
-  "animations": [],
+  "animations": [
+    "slash_reverse_oversize"
+  ],
   "credits": [
     {
       "file": "weapon/blunt/club",

--- a/sheet_definitions/weapon_blunt_flail.json
+++ b/sheet_definitions/weapon_blunt_flail.json
@@ -35,7 +35,8 @@
   ],
   "animations": [
     "walk",
-    "hurt"
+    "hurt",
+    "slash_oversize"
   ],
   "credits": [
     {

--- a/sheet_definitions/weapon_blunt_mace.json
+++ b/sheet_definitions/weapon_blunt_mace.json
@@ -35,7 +35,8 @@
   ],
   "animations": [
     "walk",
-    "hurt"
+    "hurt",
+    "slash_oversize"
   ],
   "credits": [
     {

--- a/sheet_definitions/weapon_blunt_waraxe.json
+++ b/sheet_definitions/weapon_blunt_waraxe.json
@@ -35,7 +35,8 @@
   ],
   "animations": [
     "walk",
-    "hurt"
+    "hurt",
+    "slash_oversize"
   ],
   "credits": [
     {

--- a/sheet_definitions/weapon_magic_crystal.json
+++ b/sheet_definitions/weapon_magic_crystal.json
@@ -44,7 +44,8 @@
   ],
   "animations": [
     "walk",
-    "hurt"
+    "hurt",
+    "thrust_oversize"
   ],
   "credits": [
     {

--- a/sheet_definitions/weapon_magic_diamond.json
+++ b/sheet_definitions/weapon_magic_diamond.json
@@ -50,7 +50,8 @@
   ],
   "animations": [
     "walk",
-    "hurt"
+    "hurt",
+    "thrust_oversize"
   ],
   "credits": [
     {

--- a/sheet_definitions/weapon_magic_gnarled.json
+++ b/sheet_definitions/weapon_magic_gnarled.json
@@ -50,7 +50,8 @@
   ],
   "animations": [
     "walk",
-    "hurt"
+    "hurt",
+    "thrust_oversize"
   ],
   "credits": [
     {

--- a/sheet_definitions/weapon_magic_loop.json
+++ b/sheet_definitions/weapon_magic_loop.json
@@ -50,7 +50,8 @@
   ],
   "animations": [
     "walk",
-    "hurt"
+    "hurt",
+    "thrust_oversize"
   ],
   "credits": [
     {

--- a/sheet_definitions/weapon_magic_s.json
+++ b/sheet_definitions/weapon_magic_s.json
@@ -50,7 +50,8 @@
   ],
   "animations": [
     "walk",
-    "hurt"
+    "hurt",
+    "thrust_oversize"
   ],
   "credits": [
     {

--- a/sheet_definitions/weapon_polearm_dragonspear.json
+++ b/sheet_definitions/weapon_polearm_dragonspear.json
@@ -54,7 +54,10 @@
     "silver",
     "steel"
   ],
-  "animations": [],
+  "animations": [
+    "walk_128",
+    "thrust_oversize"
+  ],
   "credits": [
     {
       "file": "weapon/polearm/dragonspear",

--- a/sheet_definitions/weapon_polearm_halberd.json
+++ b/sheet_definitions/weapon_polearm_halberd.json
@@ -53,7 +53,9 @@
   ],
   "animations": [
     "walk",
-    "hurt"
+    "hurt",
+    "thrust_oversize",
+    "slash_oversize"
   ],
   "credits": [
     {

--- a/sheet_definitions/weapon_polearm_longspear.json
+++ b/sheet_definitions/weapon_polearm_longspear.json
@@ -54,7 +54,10 @@
     "silver",
     "steel"
   ],
-  "animations": [],
+  "animations": [
+    "walk_128",
+    "thrust_oversize"
+  ],
   "credits": [
     {
       "file": "weapon/polearm/longspear",

--- a/sheet_definitions/weapon_polearm_scythe.json
+++ b/sheet_definitions/weapon_polearm_scythe.json
@@ -39,7 +39,8 @@
   ],
   "animations": [
     "walk",
-    "hurt"
+    "hurt",
+    "slash_oversize"
   ],
   "credits": [
     {

--- a/sheet_definitions/weapon_polearm_trident.json
+++ b/sheet_definitions/weapon_polearm_trident.json
@@ -54,7 +54,10 @@
     "silver",
     "steel"
   ],
-  "animations": [],
+  "animations": [
+    "walk_128",
+    "thrust_oversize"
+  ],
   "credits": [
     {
       "file": "weapon/polearm/trident",

--- a/sheet_definitions/weapon_ranged_boomerang.json
+++ b/sheet_definitions/weapon_ranged_boomerang.json
@@ -15,7 +15,9 @@
   "variants": [
     "boomerang"
   ],
-  "animations": [],
+  "animations": [
+    "slash_reverse_oversize"
+  ],
   "credits": [
     {
       "file": "weapon/ranged/boomerang",

--- a/sheet_definitions/weapon_ranged_bow_great.json
+++ b/sheet_definitions/weapon_ranged_bow_great.json
@@ -53,7 +53,8 @@
   "animations": [
     "walk",
     "shoot",
-    "hurt"
+    "hurt",
+    "walk_128"
   ],
   "credits": [
     {

--- a/sheet_definitions/weapon_ranged_bow_normal.json
+++ b/sheet_definitions/weapon_ranged_bow_normal.json
@@ -53,7 +53,8 @@
   "animations": [
     "walk",
     "shoot",
-    "hurt"
+    "hurt",
+    "walk_128"
   ],
   "credits": [
     {

--- a/sheet_definitions/weapon_ranged_bow_recurve.json
+++ b/sheet_definitions/weapon_ranged_bow_recurve.json
@@ -53,7 +53,8 @@
   "animations": [
     "walk",
     "shoot",
-    "hurt"
+    "hurt",
+    "walk_128"
   ],
   "credits": [
     {

--- a/sheet_definitions/weapon_sword_arming.json
+++ b/sheet_definitions/weapon_sword_arming.json
@@ -84,7 +84,10 @@
     "walk",
     "hurt",
     "idle",
-    "combat"
+    "combat",
+    "slash_128",
+    "backslash_128",
+    "halfslash_128"
   ],
   "credits": [
     {

--- a/sheet_definitions/weapon_sword_glowsword.json
+++ b/sheet_definitions/weapon_sword_glowsword.json
@@ -36,7 +36,8 @@
   ],
   "animations": [
     "walk",
-    "hurt"
+    "hurt",
+    "slash_oversize"
   ],
   "credits": [
     {

--- a/sheet_definitions/weapon_sword_katana.json
+++ b/sheet_definitions/weapon_sword_katana.json
@@ -41,7 +41,9 @@
   ],
   "animations": [
     "walk",
-    "hurt"
+    "hurt",
+    "walk_128",
+    "slash_128"
   ],
   "credits": [
     {

--- a/sheet_definitions/weapon_sword_longsword.json
+++ b/sheet_definitions/weapon_sword_longsword.json
@@ -67,7 +67,10 @@
   ],
   "animations": [
     "walk",
-    "hurt"
+    "hurt",
+    "slash_oversize",
+    "slash_reverse_oversize",
+    "thrust_oversize"
   ],
   "credits": [
     {

--- a/sheet_definitions/weapon_sword_longsword_alt.json
+++ b/sheet_definitions/weapon_sword_longsword_alt.json
@@ -39,7 +39,10 @@
   "variants": [
     "longsword_alt"
   ],
-  "animations": [],
+  "animations": [
+    "walk_128",
+    "slash_128"
+  ],
   "credits": [
     {
       "file": "weapon/sword/longsword_alt",

--- a/sheet_definitions/weapon_sword_rapier.json
+++ b/sheet_definitions/weapon_sword_rapier.json
@@ -35,7 +35,8 @@
   ],
   "animations": [
     "walk",
-    "hurt"
+    "hurt",
+    "slash_oversize"
   ],
   "credits": [
     {

--- a/sheet_definitions/weapon_sword_saber.json
+++ b/sheet_definitions/weapon_sword_saber.json
@@ -35,7 +35,8 @@
   ],
   "animations": [
     "walk",
-    "hurt"
+    "hurt",
+    "slash_oversize"
   ],
   "credits": [
     {

--- a/sheet_definitions/weapon_sword_scimitar.json
+++ b/sheet_definitions/weapon_sword_scimitar.json
@@ -40,7 +40,9 @@
     "scimitar"
   ],
   "animations": [
-    "walk"
+    "walk",
+    "walk_128",
+    "slash_128"
   ],
   "credits": [
     {

--- a/sheet_definitions/wheelchair.json
+++ b/sheet_definitions/wheelchair.json
@@ -25,6 +25,9 @@
     "tan",
     "white"
   ],
+  "animations": [
+    "wheelchair"
+  ],
   "credits": [
     {
       "file": "body/wheelchair",


### PR DESCRIPTION
This is an extension of: https://github.com/LiberatedPixelCup/Universal-LPC-Spritesheet-Character-Generator/pull/282

Basically, the point here is to fill out the "animations" filter entry with custom animations as well. That way, they'll show up on the compatibility list. I don't want to see any animations that show "no animation data".


Ideally it would be nice if custom animations could be filtered, too, if not by the "base" animation (slash > slash_128 / slash_oversize), or just by having all custom animations being filterable as well.