### PR TITLE
* Fixed Clearing State of Primary Color Asset

### DIFF
--- a/sources/components/tree/ItemWithRecolors.js
+++ b/sources/components/tree/ItemWithRecolors.js
@@ -41,9 +41,8 @@ export const ItemWithRecolors = {
                 rootViewNode,
                 onClose: () => { rootViewNode.state.showPaletteModal = null; m.redraw(); },
                 onSelect: (recolor) => {
-                    const subSelectGroup = (opt.type_name !== meta.type_name) ? opt.type_name : selectionGroup;
-                    selectItem(itemId, recolor, isSelected && selectedColors[subSelectGroup] === recolor, opt.type_name ? idx : null);
-                    m.redraw();
+                    const subSelectGroup = (opt.type_name !== meta.type_name) ? opt.type_name : null;
+                    selectItem(itemId, recolor, isSelected && selectedColors[subSelectGroup ?? meta.type_name] === recolor, opt.type_name ? idx : null);
                 }
             });
         }


### PR DESCRIPTION
Fixed this:
<img width="548" height="186" alt="image" src="https://github.com/user-attachments/assets/13b8a4a5-a8f6-4d68-87bd-0bfe210f3f67" />


From paint-in-place-master:
https://github.com/LiberatedPixelCup/Universal-LPC-Spritesheet-Character-Generator/pull/284#issuecomment-4024904976

Example:
<img width="860" height="374" alt="image" src="https://github.com/user-attachments/assets/2854ee03-772b-49cd-b79c-8b7aa48ca2ba" />