### PR TITLE
Security hardening: CI least-privilege & pinned installs, SRI on CDN assets, bump Mithril/Mocha/Sinon

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,29 +20,31 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      security-events: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v6
         with:
           node-version: "20"
 
 
       - name: Install Chrome
-        uses: browser-actions/setup-chrome@v2
+        uses: browser-actions/setup-chrome@v2.1.1
         with:
           chrome-version: 'latest'
 
       - name: Install Firefox
-        uses: browser-actions/setup-firefox@v1
+        uses: browser-actions/setup-firefox@v1.7.1
         with:
           firefox-version: 'latest'
 
       - name: Install Xvfb
         run: sudo apt-get install -y xvfb
+
+      - name: Install dependencies
+        run: npm ci --ignore-scripts
 
       - name: Run browser tests
         run: |
@@ -51,4 +53,4 @@ jobs:
           sleep 3
           export XDG_RUNTIME_DIR="/run/user/$(id -u)"
           export DBUS_SESSION_BUS_ADDRESS="unix:path=$XDG_RUNTIME_DIR/bus"
-          dbus-run-session npx testem ci
+          dbus-run-session npm test

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,18 +20,17 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      security-events: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v6
         with:
           node-version: "20"
 
       - name: Install dependencies
-        run: npm install
+        run: npm ci --ignore-scripts
 
       - name: Run ESLint
-        run: npx eslint .
+        run: npm run lint

--- a/.github/workflows/validate-site-sources.yml
+++ b/.github/workflows/validate-site-sources.yml
@@ -20,13 +20,12 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      security-events: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v6
         with:
           node-version: "20"
 

--- a/index.html
+++ b/index.html
@@ -4,15 +4,15 @@
 	<meta charset="utf-8">
 	<meta http-equiv="X-UA-Compatible" content="IE=Edge,chrome=1">
 	<title>Universal LPC Sprite Sheet Character Generator</title>
-	<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bulma@0.9.4/css/bulma.min.css">
+	<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bulma@0.9.4/css/bulma.min.css" integrity="sha384-HmYpsz2Aa9Gh3JlkCoh8kUJ2mUKJKTnkyC2Lzt8aLzpPOpnDe8KpFE2xNiBpMDou" crossorigin="anonymous">
 	<link rel="stylesheet" href="styles/loading.css">
 	<link rel="stylesheet" href="styles/main.css">
 	<link rel="stylesheet" href="styles/components/tree/recolors.css">
-	<script src="https://unpkg.com/mithril@2.2.2/mithril.min.js"></script>
-	<script src="https://unpkg.com/classnames@^2.5.1"></script>
+	<script src="https://unpkg.com/mithril@2.3.8/mithril.min.js" integrity="sha384-nlmjDO01tRRK0qMLxgrQdR3687yMuLHdKdwTkxa7feXSksjRmsaqG6Pv1DmNzAjb" crossorigin="anonymous"></script>
+	<script src="https://unpkg.com/classnames@2.5.1/index.js" integrity="sha384-yZ5lBIhc/erbKN+W+yrRuYTNoM3dwd0Rg2eKYqVq2bf2sUrgZxtUaaBbSscxnjRp" crossorigin="anonymous"></script>
 	<script type="text/javascript" src="sources/jszip.min.js"></script>
 	<script type="text/javascript" src="item-metadata.js?v=1.00.0001"></script>
-	<link rel="modulepreload" href="https://cdn.jsdelivr.net/npm/tinygesture@3.0.0/+esm">
+	<link rel="modulepreload" href="https://cdn.jsdelivr.net/npm/tinygesture@3.0.0/+esm" integrity="sha384-slQqJEEJRY2lwI6FvbglOo7XxdVm/c3LLyFtGT/RXw/OA9BoIy4aD7d91lQ2xX1t" crossorigin="anonymous">
 	<link rel="modulepreload" href="sources/main.js">
 </head>
 <body>

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "validate-site-sources": "node scripts/generate_sources.js",
     "z-positions": "node scripts/zPositioning/parse_zpos.js",
     "z-positions:update": "node scripts/zPositioning/update_zpos.js",
-    "test": "npx testem ci"
+    "test": "testem ci"
   },
   "devDependencies": {
     "@babel/eslint-parser": "^7.28.5",

--- a/tests_run.html
+++ b/tests_run.html
@@ -3,20 +3,24 @@
   <head>
     <meta charset="utf-8" />
     <title>Test Runner - Universal LPC Sprite Sheet</title>
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/mocha/11.7.2/mocha.css" />
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bulma@0.9.4/css/bulma.min.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/mocha@11.7.5/mocha.css" integrity="sha384-MIS4nQiXmpq495KU5RI77HGw5Jm12F00hdWw/RLQR+9bzN3Tr0FnPFljGBGt1O8i" crossorigin="anonymous" />
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bulma@0.9.4/css/bulma.min.css" integrity="sha384-HmYpsz2Aa9Gh3JlkCoh8kUJ2mUKJKTnkyC2Lzt8aLzpPOpnDe8KpFE2xNiBpMDou" crossorigin="anonymous">
     <link rel="stylesheet" href="sources/loading.css">
     <link rel="stylesheet" href="sources/main.css">
-    <script src="https://unpkg.com/mithril@2.2.2/mithril.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/mocha/11.7.2/mocha.min.js"></script>
-    <script src="https://unpkg.com/classnames@^2.5.1"></script>
+    <script src="https://unpkg.com/mithril@2.3.8/mithril.min.js" integrity="sha384-nlmjDO01tRRK0qMLxgrQdR3687yMuLHdKdwTkxa7feXSksjRmsaqG6Pv1DmNzAjb" crossorigin="anonymous"></script>
+    <script src="https://cdn.jsdelivr.net/npm/mocha@11.7.5/mocha.min.js" integrity="sha384-ubv8xN6X/ihM9F1H2WYuzSjGuSR9LM2RHHmhAk4qZN74nuE6GHjj9LsR1A9DmyLV" crossorigin="anonymous"></script>
+    <script src="https://unpkg.com/classnames@2.5.1/index.js" integrity="sha384-yZ5lBIhc/erbKN+W+yrRuYTNoM3dwd0Rg2eKYqVq2bf2sUrgZxtUaaBbSscxnjRp" crossorigin="anonymous"></script>
     <script type="text/javascript" src="sources/jszip.min.js"></script>
     <script type="text/javascript" src="item-metadata.js?v=1.00.0001"></script>
     <script type="importmap">
       {
         "imports": {
           "chai": "https://cdn.jsdelivr.net/npm/chai@6.2.2+esm",
-          "sinon": "https://cdn.jsdelivr.net/npm/sinon@21.0.1/+esm"
+          "sinon": "https://cdn.jsdelivr.net/npm/sinon@21.0.3/+esm"
+        },
+        "integrity": {
+          "https://cdn.jsdelivr.net/npm/chai@6.2.2+esm": "sha384-SWE7bILZhmiEGZEPMGrdVNNnO7SQtv32XlAQcpwNjVMXsPFsC2jPN7ccZg7LOuh1",
+          "https://cdn.jsdelivr.net/npm/sinon@21.0.3/+esm": "sha384-AoTHQuJPp8Nvy3Q9ks6RJfmIU13nPMk9nIxXSUJpOHN4AwlO/UQ93D8n1VxeQDKb"
         }
       }
     </script>


### PR DESCRIPTION
## Summary

This branch tightens the GitHub Actions setup for supply-chain and token hygiene, adds **Subresource Integrity (SRI)** for third-party script/style/module URLs in `index.html` and `tests_run.html`, and bumps several CDN dependencies (with matching integrity metadata). The `npm test` script is aligned with CI so browser tests use the lockfile-installed `testem` binary instead of `npx`.

## GitHub Actions

- **Permissions:** Removed unused `security-events: write` from all three workflows; jobs keep **`contents: read`** only.
- **Actions:** Upgraded **`actions/checkout`** and **`actions/setup-node`** to **v6**; pinned **browser-actions** to **`setup-chrome@v2.1.1`** and **`setup-firefox@v1.7.1`**.
- **Installs:** **`npm ci --ignore-scripts`** in CI and lint workflows for reproducible installs without lifecycle scripts.
- **Lint:** Runs **`npm run lint`** instead of **`npx eslint .`**.
- **Browser tests:** Adds a dependency install step; runs tests via **`dbus-run-session npm test`** (was `npx testem ci`).

## `package.json`

- **`test`:** **`testem ci`** (no `npx`), so CI uses the dependency from `npm ci` after `PATH` includes `node_modules/.bin`.

## HTML / CDN (`index.html`, `tests_run.html`)

- **SRI + `crossorigin="anonymous"`** on Bulma, Mithril, classnames, tinygesture (where applicable), Mocha assets, and **import map `integrity`** for Chai and Sinon ES-module URLs.
- **classnames:** Pinned from semver range to **`classnames@2.5.1/index.js`** for a stable URL and hash.
- **Mithril:** **2.2.2 → 2.3.8** (unpkg).
- **Mocha:** **11.7.2 → 11.7.5**, served from **jsDelivr** (`mocha.css` / `mocha.min.js`) so the version exists on the CDN used.
- **Sinon:** **21.0.1 → 21.0.3** with updated import-map integrity.

## Testing / review

- [ ] Confirm CI: lint + browser tests + validate-site-sources on this branch.
- [ ] Smoke-test the app and the Testem HTML runner in a browser (SRI failures show as blocked loads in devtools).
- [ ] **Import map `integrity`** is supported in current Chromium/Safari; if you must support very old browsers, confirm behavior.
