### PR TITLE
add overrides to fix npm audit

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "paint-in-place-for-real",
+  "name": "master",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
@@ -3013,13 +3013,13 @@
       }
     },
     "node_modules/mocha/node_modules/minimatch": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "brace-expansion": "^2.0.1"
+        "brace-expansion": "^2.0.2"
       },
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -3476,16 +3476,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/randombytes": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "^5.1.0"
-      }
-    },
     "node_modules/range-parser": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
@@ -3634,13 +3624,13 @@
       "license": "MIT"
     },
     "node_modules/serialize-javascript": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
-      "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.5.tgz",
+      "integrity": "sha512-F4LcB0UqUl1zErq+1nYEEzSHJnIwb3AF2XWB94b+afhrekOUijwooAYqFyRbjYkm2PAKBabx6oYv/xDxNi8IBw==",
       "dev": true,
       "license": "BSD-3-Clause",
-      "dependencies": {
-        "randombytes": "^2.1.0"
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/serve-static": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,9 @@
   },
   "overrides": {
     "mocha": {
-      "diff": "^8.0.3"
+      "diff": "^8.0.3",
+      "minimatch": "^9.0.7",
+      "serialize-javascript": "^7.0.5"
     }
   }
 }


### PR DESCRIPTION
# npm audit and `overrides` (Mocha transitive dependencies)

## Summary

`npm audit` can report **high-severity** findings on packages that **Mocha** pulls in as transitive dependencies (`minimatch`, `serialize-javascript`, and previously `diff`). Those packages are **devDependencies** used when running tests (e.g. via Testem); they are **not** shipped to end users as part of the site bundle.

This project uses **`package.json` → `overrides`** so nested resolution picks **patched versions** without waiting for Mocha to bump its own ranges. Overrides are scoped under `mocha` so we do not force versions across unrelated tools unless necessary.

## What the overrides address

| Package               | Typical issue                         | Mitigation (conceptually)      |
|-----------------------|---------------------------------------|--------------------------------|
| `minimatch`           | ReDoS advisories in some 9.x builds   | Resolve to **≥ 9.0.7** (v9 line) |
| `serialize-javascript`| RCE / DoS advisories in older releases| Resolve to **≥ 7.0.5**          |
| `diff`                | Prior advisory on older `diff`        | Resolve to a patched **8.x**  |

Exact ranges live in `package.json` under `overrides.mocha`.

## Risks of bumping `minimatch`

Risk is **low**: staying on **major 9** and moving from vulnerable patch levels to **9.0.7+** is a small, security-oriented change. Mocha uses `minimatch` for glob matching in the test runner. After updating the lockfile, run **`npm test`** to confirm nothing regressed.

## Risks of bumping `serialize-javascript`

`serialize-javascript` is the highest-attention case because Mocha declares a **6.x**-compatible range, while fixes require **7.0.5+** — a **major** jump when applied via overrides.

### Security context (why the bump matters)

Older versions were associated with advisories such as **unsafe handling** that could, in worst cases, tie into **RCE** or **resource exhaustion** scenarios as described in public advisories. Moving to **7.0.5+** addresses those known issues in the maintained release line.

### Compatibility and runtime scope

- **Scope:** Used in the **test toolchain** (e.g. serialization for Mocha worker / parallel flows), not in production browser assets. Failures would show up as **test runner** or **parallel test** oddities, not as silent production breakage.
- **Compatibility risk:** A new **major** may change serialization behavior or edge cases. Mocha has not necessarily certified **7.x** with your exact Mocha version, so behavior should be **validated by running the full suite**, with extra attention if you use **parallel** or **worker**-related Mocha features.

### Practical mitigation

1. Run **`npm test`** after lockfile changes.
2. If you use Mocha options that rely on worker serialization, run those paths explicitly once.
3. If something breaks, narrow the problem (repro + Mocha issue/upstream) before dropping the override; reverting the override would re-expose audit noise and known-vulnerable ranges.

## Related notes

- **`npm audit fix --force`** is often **not** appropriate here: it may **downgrade Mocha** to an ancient major and break the project.
- Upgrading to **Mocha 12** (when stable) may align declared dependencies with patched transitive versions; overrides can be revisited after major upgrades.

## References

- [npm overrides documentation](https://docs.npmjs.com/cli/v10/configuring-npm/package-json#overrides)
- Advisory details are linked from `npm audit` output and the [GitHub Advisory Database](https://github.com/advisories).