### PR TITLE
* Fixed Zip Export Not Including Recolors in Custom Standalone Assets

### DIFF
--- a/sources/state/zip.js
+++ b/sources/state/zip.js
@@ -12,6 +12,7 @@ import {
 import { getMultiRecolors } from "./palettes.js";
 import { getItemFileName } from "../utils/fileName.js";
 import { loadImage } from "../canvas/load-image.js";
+import { getImageToDraw } from "../canvas/palette-recolor.js";
 import { customAnimations, customAnimationSize } from "../custom-animations.js";
 import { getSortedLayersWithCustomFallback } from "./meta.js";
 import { canvasToBlob, image2canvas } from "../canvas/canvas-utils.js";
@@ -288,6 +289,7 @@ export const exportSplitItemSheets = async (deps = {}) => {
  * @param {typeof renderSingleItemAnimation} [deps.renderSingleItemAnimation]
  * @param {typeof loadImage} [deps.loadImage]
  * @param {typeof addStandardAnimationToZipCustomFolder} [deps.addStandardAnimationToZipCustomFolder]
+ * @param {typeof getImageToDraw} [deps.getImageToDraw]
  */
 export const exportSplitItemAnimations = async (deps = {}) => {
   const baseAddAnimationToZipFolder =
@@ -316,6 +318,7 @@ export const exportSplitItemAnimations = async (deps = {}) => {
   const renderSingleItemAnimationFn =
     deps.renderSingleItemAnimation ?? renderSingleItemAnimation;
   const loadImageFn = deps.loadImage ?? loadImage;
+  const getImageToDrawFn = deps.getImageToDraw ?? getImageToDraw;
 
   if (!guardZipExportEnvironment()) return;
 
@@ -431,6 +434,7 @@ export const exportSplitItemAnimations = async (deps = {}) => {
             `Exporting item ${itemFileName} for custom animation ${customAnimName}`,
           );
           let img;
+          let imageToDraw;
           let imgCanvas;
           await profiler.phase(
             "render_imageLoadDecode_customItemSprite",
@@ -442,7 +446,12 @@ export const exportSplitItemAnimations = async (deps = {}) => {
           await profiler.phase(
             "render_composite_customItemSprite",
             async () => {
-              imgCanvas = image2canvas(img);
+              imageToDraw = await getImageToDrawFn(
+                img,
+                layer.itemId,
+                layer.recolors,
+              );
+              imgCanvas = image2canvas(imageToDraw);
             },
           );
           if (!imgCanvas) continue;

--- a/sources/state/zip.js
+++ b/sources/state/zip.js
@@ -15,7 +15,7 @@ import { loadImage } from "../canvas/load-image.js";
 import { getImageToDraw } from "../canvas/palette-recolor.js";
 import { customAnimations, customAnimationSize } from "../custom-animations.js";
 import { getSortedLayersWithCustomFallback } from "./meta.js";
-import { canvasToBlob, image2canvas } from "../canvas/canvas-utils.js";
+import { canvasToBlob } from "../canvas/canvas-utils.js";
 import {
   addAnimationToZipFolder,
   addStandardAnimationToZipCustomFolder,
@@ -434,7 +434,6 @@ export const exportSplitItemAnimations = async (deps = {}) => {
             `Exporting item ${itemFileName} for custom animation ${customAnimName}`,
           );
           let img;
-          let imageToDraw;
           let imgCanvas;
           await profiler.phase(
             "render_imageLoadDecode_customItemSprite",
@@ -446,15 +445,11 @@ export const exportSplitItemAnimations = async (deps = {}) => {
           await profiler.phase(
             "render_composite_customItemSprite",
             async () => {
-              imageToDraw = await getImageToDrawFn(
+              imgCanvas = await getImageToDrawFn(
                 img,
                 layer.itemId,
                 layer.recolors,
               );
-              imgCanvas =
-                imageToDraw instanceof HTMLCanvasElement
-                  ? imageToDraw
-                  : image2canvas(imageToDraw);
             },
           );
           if (!imgCanvas) continue;

--- a/sources/state/zip.js
+++ b/sources/state/zip.js
@@ -451,7 +451,10 @@ export const exportSplitItemAnimations = async (deps = {}) => {
                 layer.itemId,
                 layer.recolors,
               );
-              imgCanvas = image2canvas(imageToDraw);
+              imgCanvas =
+                imageToDraw instanceof HTMLCanvasElement
+                  ? imageToDraw
+                  : image2canvas(imageToDraw);
             },
           );
           if (!imgCanvas) continue;

--- a/tests/state/zip_spec.js
+++ b/tests/state/zip_spec.js
@@ -986,9 +986,7 @@ describe("state/zip.js", () => {
       const customSpriteSourceCanvas = addCalls[0].args[2];
       expect(readTopLeftRgb(extractedSourceCanvas)).to.deep.equal([255, 0, 0]);
       expect(readTopLeftRgb(customSpriteSourceCanvas)).to.deep.equal([
-        255,
-        0,
-        0,
+        255, 0, 0,
       ]);
 
       expect(getImageToDrawStub.called).to.be.true;

--- a/tests/state/zip_spec.js
+++ b/tests/state/zip_spec.js
@@ -561,6 +561,21 @@ describe("state/zip.js", () => {
       return c;
     }
 
+    function solidColorCanvas(r, g, b, width = 8, height = 8) {
+      const c = document.createElement("canvas");
+      c.width = width;
+      c.height = height;
+      const ctx = c.getContext("2d");
+      ctx.fillStyle = `rgb(${r}, ${g}, ${b})`;
+      ctx.fillRect(0, 0, width, height);
+      return c;
+    }
+
+    function readTopLeftRgb(canvas) {
+      const data = canvas.getContext("2d").getImageData(0, 0, 1, 1).data;
+      return [data[0], data[1], data[2]];
+    }
+
     beforeEach(() => {
       resetState();
       layers.length = 0;
@@ -915,6 +930,69 @@ describe("state/zip.js", () => {
       expect(swordFolder.root).to.equal("custom/walk_128/");
       expect(swordFile).to.equal(expectedFileNames["weapon"]);
       expect(swordCanvas).to.be.instanceOf(HTMLCanvasElement);
+    });
+
+    it("uses recolored images in custom animation exports instead of raw loaded images", async () => {
+      state.selections = {
+        body: {
+          itemId: "body",
+          variant: "light",
+          recolor: "light",
+          name: "Body color (light)",
+        },
+        head: {
+          itemId: "heads_human_male",
+          variant: "light",
+          recolor: "light",
+          name: "Human male (light)",
+        },
+        weapon: {
+          itemId: "longsword",
+          variant: "longsword",
+          name: "Longsword (longsword)",
+        },
+      };
+
+      const rawLoadedCanvas = solidColorCanvas(0, 0, 255);
+      const recoloredCanvas = solidColorCanvas(255, 0, 0);
+      const loadImageStub = sandbox.stub().resolves(rawLoadedCanvas);
+      const getImageToDrawStub = sandbox.stub().resolves(recoloredCanvas);
+      const addAnimationToZipFolderSpy = sinon.spy(addAnimationToZipFolder);
+      const addStandardAnimationToZipCustomFolderSpy = sinon.spy(
+        addStandardAnimationToZipCustomFolder,
+      );
+
+      await renderCharacter(state.selections, "male");
+      await exportSplitItemAnimations({
+        loadImage: loadImageStub,
+        getImageToDraw: getImageToDrawStub,
+        addAnimationToZipFolder: addAnimationToZipFolderSpy,
+        addStandardAnimationToZipCustomFolder:
+          addStandardAnimationToZipCustomFolderSpy,
+      });
+
+      const stdToCustCalls = addStandardAnimationToZipCustomFolderSpy
+        .getCalls()
+        .filter((c) => c.args[0]?.root === "custom/walk_128/");
+      const addCalls = addAnimationToZipFolderSpy
+        .getCalls()
+        .filter((c) => c.args[0]?.root === "custom/walk_128/");
+
+      expect(stdToCustCalls, "expected extracted_frames custom exports").to.not
+        .be.empty;
+      expect(addCalls, "expected custom_sprite exports").to.not.be.empty;
+
+      const extractedSourceCanvas = stdToCustCalls[0].args[2];
+      const customSpriteSourceCanvas = addCalls[0].args[2];
+      expect(readTopLeftRgb(extractedSourceCanvas)).to.deep.equal([255, 0, 0]);
+      expect(readTopLeftRgb(customSpriteSourceCanvas)).to.deep.equal([
+        255,
+        0,
+        0,
+      ]);
+
+      expect(getImageToDrawStub.called).to.be.true;
+      expect(loadImageStub.called).to.be.true;
     });
 
     describe("issue #364 (custom-animation-only items)", () => {

--- a/tests/state/zip_spec.js
+++ b/tests/state/zip_spec.js
@@ -572,9 +572,57 @@ describe("state/zip.js", () => {
     }
 
     function readTopLeftRgb(canvas) {
-      const data = canvas.getContext("2d").getImageData(0, 0, 1, 1).data;
+      if (!(canvas instanceof HTMLCanvasElement)) {
+        throw new TypeError("readTopLeftRgb expects an HTMLCanvasElement");
+      }
+
+      const ctx = canvas.getContext("2d");
+      if (!ctx) {
+        throw new Error("Failed to get 2d context from canvas");
+      }
+
+      const data = ctx.getImageData(0, 0, 1, 1).data;
       return [data[0], data[1], data[2]];
     }
+
+    describe("helper functions", () => {
+      it("solidColorCanvas creates an 8x8 canvas by default", () => {
+        const c = solidColorCanvas(1, 2, 3);
+        expect(c).to.be.instanceOf(HTMLCanvasElement);
+        expect(c.width).to.equal(8);
+        expect(c.height).to.equal(8);
+      });
+
+      it("solidColorCanvas paints the requested RGB color", () => {
+        const c = solidColorCanvas(12, 34, 56, 4, 4);
+        expect(readTopLeftRgb(c)).to.deep.equal([12, 34, 56]);
+      });
+
+      it("readTopLeftRgb throws for null or undefined input", () => {
+        expect(() => readTopLeftRgb(null)).to.throw(
+          TypeError,
+          "readTopLeftRgb expects an HTMLCanvasElement",
+        );
+        expect(() => readTopLeftRgb(undefined)).to.throw(
+          TypeError,
+          "readTopLeftRgb expects an HTMLCanvasElement",
+        );
+      });
+
+      it("readTopLeftRgb throws for non-canvas input", () => {
+        expect(() => readTopLeftRgb({})).to.throw(
+          TypeError,
+          "readTopLeftRgb expects an HTMLCanvasElement",
+        );
+      });
+
+      it("readTopLeftRgb returns black for a blank transparent canvas", () => {
+        const c = document.createElement("canvas");
+        c.width = 2;
+        c.height = 2;
+        expect(readTopLeftRgb(c)).to.deep.equal([0, 0, 0]);
+      });
+    });
 
     beforeEach(() => {
       resetState();

--- a/tests/state/zip_spec.js
+++ b/tests/state/zip_spec.js
@@ -598,6 +598,24 @@ describe("state/zip.js", () => {
         expect(readTopLeftRgb(c)).to.deep.equal([12, 34, 56]);
       });
 
+      it("readTopLeftRgb returns RGB values for a normal filled canvas", () => {
+        const c = solidColorCanvas(200, 150, 100, 3, 3);
+        expect(readTopLeftRgb(c)).to.deep.equal([200, 150, 100]);
+      });
+
+      it("readTopLeftRgb reads the top-left pixel specifically", () => {
+        const c = document.createElement("canvas");
+        c.width = 2;
+        c.height = 2;
+        const ctx = c.getContext("2d");
+        ctx.fillStyle = "rgb(5, 10, 15)";
+        ctx.fillRect(0, 0, 1, 1);
+        ctx.fillStyle = "rgb(250, 240, 230)";
+        ctx.fillRect(1, 1, 1, 1);
+
+        expect(readTopLeftRgb(c)).to.deep.equal([5, 10, 15]);
+      });
+
       it("readTopLeftRgb throws for null or undefined input", () => {
         expect(() => readTopLeftRgb(null)).to.throw(
           TypeError,


### PR DESCRIPTION
resolves #394 


The issue is that the new assets weren't configured correctly to use the recolor script.

I also added tests for it, too, with help from Copilot of course.