### PR TITLE
Do not pretty print item-metadata.js in production

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ computed-style-diff-output/
 /dist/
 **/__screenshots__/
 /.vitest-attachments/
+.tool-versions

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -201,6 +201,8 @@ For visual tests only, **`npx playwright install chromium`** is enough. The Argo
 
 The runtime UI loads **`dist/item-metadata.js`**, which Vite generates from the sheet JSON under **`sheet_definitions/`** (and related inputs) when you run **`npm run dev`** or **`npm run build`**. Do not edit that file by hand.
 
+The JSON embedded in each `const` assignment is **pretty-printed** when Vite runs in development (**`npm run dev`**) and **compact** (no indentation inside those objects) when Vite runs a production build (**`npm run build`**). Inspecting **`dist/item-metadata.js`** after a dev run is easier; CI and release artifacts use the compact form.
+
 **Credits and z-positions (committed files)** — From the project root:
 
 ```bash

--- a/PALETTE_RECOLOR_GUIDE.md
+++ b/PALETTE_RECOLOR_GUIDE.md
@@ -412,7 +412,7 @@ Regenerate the catalog bundle with Vite so `dist/item-metadata.js` includes the 
 npm run dev
 ```
 
-(or `npm run build` once). `node scripts/generate_sources.mjs` updates **CREDITS.csv** and z-positions but does not write `dist/item-metadata.js`.
+(or `npm run build` once). `node scripts/generate_sources.mjs` updates **CREDITS.csv** and z-positions but does not write `dist/item-metadata.js`. After **`npm run dev`**, open **`dist/item-metadata.js`** to inspect the catalog with readable indentation; after **`npm run build`**, the same file is compact (no pretty-printed JSON).
 
 ### Step 5: Ensure Source Variant Exists
 

--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ If an engine is not listed above, try Google. However, it is very likely that yo
 - **Format:** `npm run format:check` (verify) or `npm run format` (apply)
 - **Tests:** `npm test` (Node checks plus browser tests). Visual regression: `npm run test:visual`. Details are in [CONTRIBUTING.md](CONTRIBUTING.md).
 
-**Generated files:** [CREDITS.csv](CREDITS.csv) is updated by **`node scripts/generate_sources.mjs`** (also **`npm run validate-site-sources`**), together with z-position CSV under **`scripts/zPositioning/`**. The runtime catalog bundle **`dist/item-metadata.js`** is produced by **Vite** (`npm run dev`, `npm run build`); it is gitignored—do not edit it by hand. See [CONTRIBUTING.md](CONTRIBUTING.md) for the full workflow.
+**Generated files:** [CREDITS.csv](CREDITS.csv) is updated by **`node scripts/generate_sources.mjs`** (also **`npm run validate-site-sources`**), together with z-position CSV under **`scripts/zPositioning/`**. The runtime catalog bundle **`dist/item-metadata.js`** is produced by **Vite** (`npm run dev`, `npm run build`); it is gitignored—do not edit it by hand. **`npm run dev`** writes that bundle with pretty-printed embedded JSON; **`npm run build`** writes compact JSON. See [CONTRIBUTING.md](CONTRIBUTING.md) for the full workflow.
 
 #### Performance Profiling
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "feature",
+  "name": "master",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/scripts/generateSources/state.mjs
+++ b/scripts/generateSources/state.mjs
@@ -87,13 +87,24 @@ export function parseJson(fullPath) {
  * Builds browser-side metadata bootstrap JS from shared generator state.
  * Emits an ES module (named exports) so Vite/Vitest can import it; also assigns
  * onto `window` when running in a browser so plain script or VM-style eval still works.
+ * @param {"development"|"production"} [env="production"] Vite passes `development` for
+ *   `npm run dev` (pretty-printed embedded JSON) and `production` for `npm run build`
+ *   (compact JSON).
  * @return {string} JavaScript module source for item-metadata.js.
  */
-export function buildMetadataJs() {
-  const itemJson = JSON.stringify(itemMetadata, null, 2);
-  const aliasJson = JSON.stringify(aliasMetadata, null, 2);
-  const treeJson = JSON.stringify(categoryTree, null, 2);
-  const paletteJson = JSON.stringify(paletteMetadata, null, 2);
+export function buildMetadataJs(env = "production") {
+  let itemJson, aliasJson, treeJson, paletteJson;
+  if (env === "development") {
+    itemJson = JSON.stringify(itemMetadata, null, 2);
+    aliasJson = JSON.stringify(aliasMetadata, null, 2);
+    treeJson = JSON.stringify(categoryTree, null, 2);
+    paletteJson = JSON.stringify(paletteMetadata, null, 2);
+  } else {
+    itemJson = JSON.stringify(itemMetadata);
+    aliasJson = JSON.stringify(aliasMetadata);
+    treeJson = JSON.stringify(categoryTree);
+    paletteJson = JSON.stringify(paletteMetadata);
+  }
   return `// THIS FILE IS AUTO-GENERATED. PLEASE DON'T ALTER IT MANUALLY
   // Generated from sheet_definitions/*.json by scripts/generate_sources.mjs
   // Contains metadata for all customization items to avoid DOM queries at runtime

--- a/scripts/generate_sources.mjs
+++ b/scripts/generate_sources.mjs
@@ -22,7 +22,7 @@ import {
   readDirTree,
 } from "./generateSources/state.mjs";
 
-export function generateSources(deps = {}) {
+export function generateSources(deps = {}, env = "production") {
   const writeFileSyncFn = deps.writeFileSync ?? fs.writeFileSync;
   const parseTreeFn = deps.parseTreeFn ?? parseTree;
   const parseItemFn = deps.parseItemFn ?? parseItem;
@@ -73,7 +73,7 @@ export function generateSources(deps = {}) {
 
   // Build and write item-metadata.js (optional: CLI / tests skip; Vite plugin enables)
   if (writeMetadata) {
-    const metadataJS = buildMetadataJs();
+    const metadataJS = buildMetadataJs(env);
     try {
       writeFileSyncFn(metadataOutputPath, metadataJS);
       process.stdout.write("Item Metadata JS Updated!\n");

--- a/tests/node/scripts/generateSources/state_spec.js
+++ b/tests/node/scripts/generateSources/state_spec.js
@@ -59,6 +59,28 @@ test("buildMetadataJs returns valid output with empty state", () => {
   assert.match(js, /const aliasMetadata = \{\}/);
 });
 
+test("buildMetadataJs pretty-prints embedded JSON in development only", () => {
+  resetTestState();
+  itemMetadata.nested = { bar: 1 };
+
+  const production = buildMetadataJs("production");
+  const development = buildMetadataJs("development");
+
+  assert.ok(
+    production.includes('"bar":1'),
+    "production should emit compact JSON (no space after colon in numbers)",
+  );
+  assert.ok(
+    development.includes('"bar": 1'),
+    "development should emit pretty-printed JSON",
+  );
+  assert.ok(
+    development.includes("\n"),
+    "development output should include newlines inside embedded JSON",
+  );
+  assert.equal(buildMetadataJs(), production);
+});
+
 test("sortDirTree sorts shallow paths before deep paths", () => {
   const entries = [
     { parentPath: path.join("a", "b"), name: "z.json" },

--- a/vite.config.js
+++ b/vite.config.js
@@ -65,7 +65,7 @@ export default defineConfig(({ command }) => ({
     target: false,
   },
   plugins: [
-    ...itemMetadataPlugins(),
+    ...itemMetadataPlugins(command),
     vitePluginBundledCssAfterBulma(),
     getSpritesheetsPlugin(command),
   ],

--- a/vite/vite-plugin-item-metadata.js
+++ b/vite/vite-plugin-item-metadata.js
@@ -21,9 +21,11 @@ function isPathInside(filePath, dirPath) {
  * `palette_definitions/` before bundling. Does not fork z-position tooling (CLI only).
  * Skips writing `CREDITS.csv` so dev/build do not dirty the repo.
  *
+ * @param {"development"|"production"} [env="production"] Passed through to
+ *   `buildMetadataJs`: development pretty-prints embedded JSON; production does not.
  * @returns {import("vite").Plugin}
  */
-export function vitePluginItemMetadata() {
+export function vitePluginItemMetadata(env = "production") {
   let root = process.cwd();
   let debounceTimer = null;
 
@@ -39,6 +41,7 @@ export function vitePluginItemMetadata() {
         }
         fs.writeFileSync(filePath, contents);
       },
+      env,
     });
   }
 

--- a/vite/wiring.js
+++ b/vite/wiring.js
@@ -27,6 +27,7 @@ export function itemMetadataResolveAliases() {
  * Runs on **serve** and **build** (no `apply` filter).
  * @returns {import("vite").Plugin[]}
  */
-export function itemMetadataPlugins() {
-  return [vitePluginItemMetadata()];
+export function itemMetadataPlugins(command) {
+  const env = command === "build" ? "production" : "development";
+  return [vitePluginItemMetadata(env)];
 }


### PR DESCRIPTION
#### File Generation

The runtime UI loads **`dist/item-metadata.js`**, which Vite generates from the sheet JSON under **`sheet_definitions/`** (and related inputs) when you run **`npm run dev`** or **`npm run build`**. Do not edit that file by hand.

The JSON embedded in each `const` assignment is **pretty-printed** when Vite runs in development (**`npm run dev`**) and **compact** (no indentation inside those objects) when Vite runs a production build (**`npm run build`**). Inspecting **`dist/item-metadata.js`** after a dev run is easier; CI and release artifacts use the compact form.