### PR TITLE
Fix #435: Align directions in zip by frame

### DIFF
--- a/sources/state/constants.js
+++ b/sources/state/constants.js
@@ -15,6 +15,9 @@ export const BODY_TYPES = [
   "pregnant",
 ];
 
+// LPC sheet row order: should match ANIMATION_CONFIGS rows
+export const DIRECTIONS = ["up", "left", "down", "right"];
+
 // License configuration - single source of truth
 export const LICENSE_CONFIG = [
   {

--- a/sources/state/zip.js
+++ b/sources/state/zip.js
@@ -1,4 +1,9 @@
-import { ANIMATIONS, ANIMATION_CONFIGS, FRAME_SIZE } from "./constants.js";
+import {
+  ANIMATIONS,
+  ANIMATION_CONFIGS,
+  FRAME_SIZE,
+  DIRECTIONS,
+} from "./constants.js";
 import {
   extractAnimationFromCanvas,
   renderSingleItem,
@@ -593,7 +598,7 @@ export const exportIndividualFrames = async (deps = {}) => {
 
     const exportedAnimations = [];
     const failedAnimations = [];
-    const directions = ["up", "down", "left", "right"];
+    const directions = DIRECTIONS;
 
     // Pre-extract, slice to per-frame canvases, and queue PNG encodes (render path)
     const animationCanvases = new Map();

--- a/sources/utils/zip-helpers.js
+++ b/sources/utils/zip-helpers.js
@@ -2,6 +2,7 @@ import {
   ANIMATION_CONFIGS,
   FRAME_SIZE,
   STANDARD_ANIMATION_FRAMES_PER_ROW,
+  DIRECTIONS,
 } from "../state/constants.js";
 import { drawFramesToCustomAnimation } from "../canvas/draw-frames.js";
 import { customAnimationSize } from "../custom-animations.js";
@@ -17,13 +18,14 @@ import { exportStateAsJSON } from "../state/json.js";
 /**
  * Maps direction names to row indices on a custom-animation grid (LPC order:
  * up, left, down, right).
+ * Should match DIRECTIONS from constants.js
  */
-export const CUSTOM_ANIM_DIRECTION_TO_ROW = Object.freeze({
-  up: 0,
-  left: 1,
-  down: 2,
-  right: 3,
-});
+export const CUSTOM_ANIM_DIRECTION_TO_ROW = Object.freeze(
+  DIRECTIONS.reduce((acc, dir, index) => {
+    acc[dir] = index;
+    return acc;
+  }, {}),
+);
 
 function createFrameCanvasPool(poolSize, frameWidth, frameHeight) {
   const canvasPool = [];
@@ -279,7 +281,7 @@ export async function addStandardAnimationToZipCustomFolder(
 export function extractFramesFromAnimation(
   animationCanvas,
   animationName,
-  directions = ["up", "down", "left", "right"],
+  directions = DIRECTIONS,
 ) {
   const frames = {};
   const config = ANIMATION_CONFIGS[animationName];
@@ -385,7 +387,7 @@ export function checkFrameContentFromImageData(
 export function extractFramesFromCustomAnimation(
   animationCanvas,
   customAnimationDef,
-  directions = ["up", "down", "left", "right"],
+  directions = DIRECTIONS,
 ) {
   const frames = {};
   const frameSize = customAnimationDef.frameSize;

--- a/tests/state/zip_spec.js
+++ b/tests/state/zip_spec.js
@@ -23,7 +23,7 @@ import {
 } from "../../sources/state/zip.js";
 import { resetState } from "../../sources/state/hash.js";
 import { state } from "../../sources/state/state.js";
-import { ANIMATIONS } from "../../sources/state/constants.js";
+import { ANIMATIONS, DIRECTIONS } from "../../sources/state/constants.js";
 import { createFakeJSZip } from "../helpers/fake-jszip.js";
 
 /**
@@ -1103,7 +1103,7 @@ describe("state/zip.js", () => {
     let fakeZip;
     let alertStub;
 
-    const directions = ["up", "down", "left", "right"];
+    const directions = DIRECTIONS;
 
     function smallAnimCanvas() {
       const c = document.createElement("canvas");

--- a/tests/utils/zip-helpers_spec.js
+++ b/tests/utils/zip-helpers_spec.js
@@ -20,6 +20,7 @@ import {
   zipExportTimestamp,
   zipGenerateBlobWithProfiler,
 } from "../../sources/utils/zip-helpers.js";
+import { DIRECTIONS } from "../../sources/state/constants.js";
 
 function createCanvas(width, height) {
   const canvas = document.createElement("canvas");
@@ -366,8 +367,8 @@ describe("utils/zip-helpers.js", () => {
 
       const out = extractFramesFromAnimation(canvas, "walk");
 
-      expect(out.down).to.have.length(1);
-      expect(out.down[0].frameNumber).to.equal(1);
+      expect(out.left).to.have.length(1);
+      expect(out.left[0].frameNumber).to.equal(1);
       expect(out.up).to.deep.equal([]);
     });
 
@@ -481,7 +482,7 @@ describe("utils/zip-helpers.js", () => {
         "right",
         "up",
       ]);
-      for (const dir of ["up", "down", "left", "right"]) {
+      for (const dir of DIRECTIONS) {
         expect(out[dir]).to.have.length(2);
         expect(out[dir][0].frameNumber).to.equal(1);
         expect(out[dir][1].frameNumber).to.equal(2);


### PR DESCRIPTION
Correct LPC row order is up, left, down, right.