### PR TITLE
Speed up renderCharacter: cache, single-pass, preview guard (#418)

### DIFF
--- a/sources/canvas/palette-recolor.js
+++ b/sources/canvas/palette-recolor.js
@@ -93,13 +93,15 @@ function findMatchingColor(r, g, b, colorPairs, tolerance = 1) {
 }
 
 /**
- * Recolor an image using palette mapping (CPU implementation)
+ * Recolor an image using palette mapping (CPU implementation).
+ * Accepts a list of (source, target) palette mappings; all mappings are
+ * flattened into a single list of color pairs, then each pixel is tested
+ * against every pair in one pass.
  * @param {HTMLImageElement|HTMLCanvasElement} sourceImage - Source image
- * @param {string[]} sourcePalette - Array of hex colors (source)
- * @param {string[]} targetPalette - Array of hex colors (target)
+ * @param {Array<{source: string[], target: string[]}>} paletteMappings
  * @returns {HTMLCanvasElement} Recolored canvas
  */
-function recolorImageCPU(sourceImage, sourcePalette, targetPalette) {
+function recolorImageCPU(sourceImage, paletteMappings) {
   // Create offscreen canvas
   const canvas = document.createElement("canvas");
   canvas.width = sourceImage.width;
@@ -113,8 +115,12 @@ function recolorImageCPU(sourceImage, sourcePalette, targetPalette) {
   const imageData = ctx.getImageData(0, 0, canvas.width, canvas.height);
   const pixels = imageData.data;
 
-  // Build color mapping
-  const colorPairs = buildColorMap(sourcePalette, targetPalette);
+  // Flatten all mappings into a single color pair list
+  const colorPairs = [];
+  for (const { source, target } of paletteMappings) {
+    const pairs = buildColorMap(source, target);
+    for (const p of pairs) colorPairs.push(p);
+  }
 
   // Recolor pixels with tolerance matching (like WebGL)
   for (let i = 0; i < pixels.length; i += 4) {
@@ -193,29 +199,28 @@ export function getPaletteRecolorConfig() {
 }
 
 /**
- * Recolor an image using palette mapping
- * Automatically uses WebGL if available, falls back to CPU
+ * Recolor an image using one or more palette mappings in a single pass.
+ * Automatically uses WebGL if available, falls back to CPU.
  * @param {HTMLImageElement|HTMLCanvasElement} sourceImage - Source image
- * @param {string[]} sourcePalette - Array of hex colors (source)
- * @param {string[]} targetPalette - Array of hex colors (target)
+ * @param {Array<{source: string[], target: string[]}>} paletteMappings
  * @returns {HTMLCanvasElement} Recolored canvas
  */
-export function recolorImage(sourceImage, sourcePalette, targetPalette) {
+export function recolorImage(sourceImage, paletteMappings) {
   const shouldUseWebGL = config.useWebGL && !config.forceCPU;
 
   if (shouldUseWebGL) {
     try {
       recolorStats.webgl++;
-      return recolorImageWebGL(sourceImage, sourcePalette, targetPalette);
+      return recolorImageWebGL(sourceImage, paletteMappings);
     } catch (error) {
       // eslint-disable-next-line no-console
       console.warn("⚠️ WebGL recoloring failed, falling back to CPU:", error);
       recolorStats.fallback++;
-      return recolorImageCPU(sourceImage, sourcePalette, targetPalette);
+      return recolorImageCPU(sourceImage, paletteMappings);
     }
   }
   recolorStats.cpu++;
-  return recolorImageCPU(sourceImage, sourcePalette, targetPalette);
+  return recolorImageCPU(sourceImage, paletteMappings);
 }
 
 /**
@@ -232,33 +237,84 @@ export async function loadPalette(url) {
 }
 
 /**
- * Get image to draw - applies recoloring if needed based on palette configuration
- * Async because palette loading is lazy (loads on first use)
+ * Bounded LRU cache of recolored canvases, keyed by (spritePath, recolors).
+ * A JS Map preserves insertion order; `get → delete → set` moves an entry to
+ * the end (most-recently-used), and eviction always drops the head.
+ *
+ * We store the in-flight Promise rather than the resolved canvas so that
+ * concurrent callers for the same key (e.g. main render + a tree preview)
+ * share one recolor operation instead of starting duplicates.
+ */
+const RECOLOR_CACHE_CAP = 250;
+const recolorCache = new Map();
+
+/**
+ * Get image to draw - applies recoloring if needed based on palette configuration.
+ * Async because palette loading is lazy (loads on first use). When `spritePath`
+ * is supplied, the recolored result is memoized so repeated renders for the
+ * same (spritePath, recolors) skip the entire recolor pipeline.
+ *
  * @param {HTMLImageElement|HTMLCanvasElement} img - Source image
  * @param {string} itemId - Item identifier
  * @param {Object} recolors - Recolor names
+ * @param {string|null} [spritePath] - Source sprite URL (enables caching when set)
  * @returns {Promise<HTMLImageElement|HTMLCanvasElement>} Image or recolored canvas to draw
  */
-export async function getImageToDraw(img, itemId, recolors) {
+export async function getImageToDraw(img, itemId, recolors, spritePath = null) {
   if (!recolors) {
     return img; // No recolor specified, return original image
   }
   const meta = window.itemMetadata?.[itemId];
   const paletteConfig = getPalettesForItem(itemId, meta);
+  if (!paletteConfig) {
+    return img; // Item doesn't use palette recoloring
+  }
 
-  // Only recolor if item uses a palette and color is not the source color
-  if (paletteConfig && recolors) {
-    try {
-      return await recolorWithPalette(img, recolors, paletteConfig);
-    } catch (err) {
-      console.error(
-        `Failed to recolor ${paletteConfig[meta.type_name].material} color ${JSON.stringify(recolors)}:`,
-        err,
-      );
-      return img; // Fallback to original on error
+  const cacheKey = spritePath
+    ? `${spritePath}|${JSON.stringify(recolors)}`
+    : null;
+  if (cacheKey) {
+    const hit = recolorCache.get(cacheKey);
+    if (hit) {
+      // LRU touch
+      recolorCache.delete(cacheKey);
+      recolorCache.set(cacheKey, hit);
+      return hit;
     }
   }
-  return img; // Return original if no recoloring needed
+
+  const promise = recolorWithPalette(img, recolors, paletteConfig);
+
+  if (cacheKey) {
+    recolorCache.set(cacheKey, promise);
+    // On rejection, drop the entry so retries aren't poisoned by a stale failure.
+    promise.catch(() => {
+      if (recolorCache.get(cacheKey) === promise) {
+        recolorCache.delete(cacheKey);
+      }
+    });
+    while (recolorCache.size > RECOLOR_CACHE_CAP) {
+      const oldestKey = recolorCache.keys().next().value;
+      recolorCache.delete(oldestKey);
+    }
+  }
+
+  try {
+    return await promise;
+  } catch (err) {
+    console.error(
+      `Failed to recolor ${paletteConfig[meta.type_name].material} color ${JSON.stringify(recolors)}:`,
+      err,
+    );
+    return img; // Fallback to original on error
+  }
+}
+
+/**
+ * Clear the recolor cache. Mainly for tests; callable at runtime too.
+ */
+export function clearRecolorCache() {
+  recolorCache.clear();
 }
 
 /**
@@ -274,9 +330,10 @@ export async function recolorWithPalette(
   targetColors,
   sourcePalettes,
 ) {
-  // Loop All Palettes to Recolor
+  // Gather all (source, target) palette mappings so they can be applied
+  // in a single shader pass.
+  const mappings = [];
   for (const [typeName, palette] of Object.entries(sourcePalettes)) {
-    // Get Target Palette
     const targetPalette = getTargetPalette(
       palette.material,
       targetColors[typeName],
@@ -286,10 +343,12 @@ export async function recolorWithPalette(
         `Unknown target palette color: ${JSON.stringify(targetColors)}`,
       );
     }
-
-    sourceImage = recolorImage(sourceImage, palette.colors, targetPalette);
+    mappings.push({ source: palette.colors, target: targetPalette });
   }
-  return sourceImage;
+
+  return mappings.length > 0
+    ? recolorImage(sourceImage, mappings)
+    : sourceImage;
 }
 
 /**
@@ -359,13 +418,18 @@ export async function drawRecolorPreview(
   ctx.clearRect(0, 0, canvas.width, canvas.height);
   // Draw each layer in zPos order
   imagesLoaded = 0;
-  for (const { img } of loadedLayers) {
+  for (const { img, layer } of loadedLayers) {
     if (isStaleRender()) {
       return 0;
     }
 
     if (img) {
-      const imageToDraw = await getImageToDraw(img, itemId, selectedColors);
+      const imageToDraw = await getImageToDraw(
+        img,
+        itemId,
+        selectedColors,
+        layer.path,
+      );
       const size = compactDisplay ? COMPACT_FRAME_SIZE : FRAME_SIZE;
       const srcX = previewCol * FRAME_SIZE + previewXOffset;
       const srcY = previewRow * FRAME_SIZE + previewYOffset;

--- a/sources/canvas/renderer.js
+++ b/sources/canvas/renderer.js
@@ -343,6 +343,7 @@ export async function renderCharacter(
           img,
           item.itemId,
           item.recolors,
+          item.spritePath,
         );
         renderCtx.drawImage(imageToDraw, 0, item.yPos);
       }
@@ -416,6 +417,7 @@ export async function renderCharacter(
               img,
               areaItem.itemId,
               areaItem.recolors,
+              areaItem.spritePath,
             );
 
             if (areaItem.type === "custom_sprite") {
@@ -600,7 +602,12 @@ export async function renderSingleItem(
       async () => {
         for (const { item: sprite, img, success } of loadedSprites) {
           if (success && img) {
-            const imageToDraw = await getImageToDraw(img, itemId, recolors);
+            const imageToDraw = await getImageToDraw(
+              img,
+              itemId,
+              recolors,
+              sprite.spritePath,
+            );
             itemCtx.drawImage(imageToDraw, 0, sprite.yPos);
           }
         }
@@ -686,6 +693,7 @@ export async function renderSingleItem(
               img,
               itemId,
               sprite.recolors,
+              sprite.spritePath,
             );
             itemCtx.drawImage(imageToDraw, 0, sprite.yPos);
           }
@@ -820,6 +828,7 @@ export async function renderSingleItemAnimation(
             img,
             itemId,
             sprite.recolors,
+            sprite.spritePath,
           );
           animCtx.drawImage(
             imageToDraw,

--- a/sources/canvas/webgl-palette-recolor.js
+++ b/sources/canvas/webgl-palette-recolor.js
@@ -129,32 +129,34 @@ function hexToRgbNormalized(hex) {
 }
 
 /**
- * Create a palette texture from source and target palettes
+ * Create a palette texture from one or more palette mappings.
+ * All source colors are concatenated into row 0; target colors at the same
+ * index sit in row 1. The shader loops up to `u_paletteSize` slots, so N
+ * regions can be recolored in a single pass by packing them back-to-back.
  * @param {WebGLRenderingContext} gl - WebGL context
- * @param {string[]} sourcePalette - Array of hex colors (source)
- * @param {string[]} targetPalette - Array of hex colors (target)
- * @returns {WebGLTexture} Palette texture
+ * @param {Array<{source: string[], target: string[]}>} paletteMappings
+ * @returns {{ texture: WebGLTexture, totalSize: number }}
  */
-function createPaletteTexture(gl, sourcePalette, targetPalette) {
+function createPaletteTexture(gl, paletteMappings) {
   const data = new Uint8Array(32 * 2 * 4); // 32 colors × 2 rows × RGBA
+  const TARGET_ROW_OFFSET = 32 * 4;
 
-  // First row: source colors
-  for (let i = 0; i < sourcePalette.length; i++) {
-    const rgb = hexToRgbNormalized(sourcePalette[i]);
-    data[i * 4 + 0] = Math.round(rgb[0] * 255);
-    data[i * 4 + 1] = Math.round(rgb[1] * 255);
-    data[i * 4 + 2] = Math.round(rgb[2] * 255);
-    data[i * 4 + 3] = 255;
-  }
+  let slot = 0;
+  for (const { source, target } of paletteMappings) {
+    const n = Math.min(source.length, target.length);
+    for (let i = 0; i < n && slot < 32; i++, slot++) {
+      const srcRgb = hexToRgbNormalized(source[i]);
+      data[slot * 4 + 0] = Math.round(srcRgb[0] * 255);
+      data[slot * 4 + 1] = Math.round(srcRgb[1] * 255);
+      data[slot * 4 + 2] = Math.round(srcRgb[2] * 255);
+      data[slot * 4 + 3] = 255;
 
-  // Second row: target colors
-  for (let i = 0; i < targetPalette.length; i++) {
-    const rgb = hexToRgbNormalized(targetPalette[i]);
-    const offset = 32 * 4; // Second row offset
-    data[offset + i * 4 + 0] = Math.round(rgb[0] * 255);
-    data[offset + i * 4 + 1] = Math.round(rgb[1] * 255);
-    data[offset + i * 4 + 2] = Math.round(rgb[2] * 255);
-    data[offset + i * 4 + 3] = 255;
+      const tgtRgb = hexToRgbNormalized(target[i]);
+      data[TARGET_ROW_OFFSET + slot * 4 + 0] = Math.round(tgtRgb[0] * 255);
+      data[TARGET_ROW_OFFSET + slot * 4 + 1] = Math.round(tgtRgb[1] * 255);
+      data[TARGET_ROW_OFFSET + slot * 4 + 2] = Math.round(tgtRgb[2] * 255);
+      data[TARGET_ROW_OFFSET + slot * 4 + 3] = 255;
+    }
   }
 
   const texture = gl.createTexture();
@@ -175,7 +177,7 @@ function createPaletteTexture(gl, sourcePalette, targetPalette) {
   gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
   gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
 
-  return texture;
+  return { texture, totalSize: slot };
 }
 
 /**
@@ -265,13 +267,15 @@ function initSharedWebGL() {
 }
 
 /**
- * Recolor an image using WebGL palette mapping (with shared context)
+ * Recolor an image using WebGL palette mapping (with shared context).
+ * Accepts a list of (source, target) palette mappings and applies them all in
+ * a single shader pass by packing them into one palette texture. The combined
+ * total must fit within the 32-slot palette texture.
  * @param {HTMLImageElement|HTMLCanvasElement} sourceImage - Source image
- * @param {string[]} sourcePalette - Array of hex colors (source)
- * @param {string[]} targetPalette - Array of hex colors (target)
+ * @param {Array<{source: string[], target: string[]}>} paletteMappings
  * @returns {HTMLCanvasElement} Recolored canvas
  */
-export function recolorImageWebGL(sourceImage, sourcePalette, targetPalette) {
+export function recolorImageWebGL(sourceImage, paletteMappings) {
   // Initialize shared resources if needed
   if (!sharedGL) {
     initSharedWebGL();
@@ -295,10 +299,9 @@ export function recolorImageWebGL(sourceImage, sourcePalette, targetPalette) {
 
     // Create textures (these are temporary and must be created per operation)
     const imageTexture = createImageTexture(gl, sourceImage);
-    const paletteTexture = createPaletteTexture(
+    const { texture: paletteTexture, totalSize } = createPaletteTexture(
       gl,
-      sourcePalette,
-      targetPalette,
+      paletteMappings,
     );
 
     // Set uniforms
@@ -311,7 +314,7 @@ export function recolorImageWebGL(sourceImage, sourcePalette, targetPalette) {
 
     gl.uniform1i(imageLocation, 0);
     gl.uniform1i(paletteLocation, 1);
-    gl.uniform1f(paletteSizeLocation, sourcePalette.length);
+    gl.uniform1f(paletteSizeLocation, totalSize);
 
     // Bind textures
     gl.activeTexture(gl.TEXTURE0);

--- a/sources/components/tree/ItemWithRecolors.js
+++ b/sources/components/tree/ItemWithRecolors.js
@@ -128,36 +128,38 @@ export const ItemWithRecolors = {
                           ? COMPACT_FRAME_SIZE
                           : FRAME_SIZE,
                         class: compactDisplay ? " compact-display" : "",
-                        oncreate: async (canvasVnode) => {
-                          const imagesLoaded = drawRecolorPreview(
+                        oncreate: (canvasVnode) => {
+                          const renderId =
+                            (canvasVnode.dom._recolorRenderId || 0) + 1;
+                          canvasVnode.dom._recolorRenderId = renderId;
+                          canvasVnode.state.lastColorsKey =
+                            JSON.stringify(selectedColors);
+                          drawRecolorPreview(
                             itemId,
                             meta,
                             canvasVnode.dom,
                             selectedColors,
+                            renderId,
                           );
-                          if (imagesLoaded > 0) {
-                            rootViewNode.state.imagesLoaded += imagesLoaded;
-                            rootViewNode.state.oldSelectedColors =
-                              JSON.stringify(selectedColors);
-                          }
                         },
-                        onupdate: async (canvasVnode) => {
-                          if (
-                            rootViewNode.state.oldSelectedColors ===
-                            JSON.stringify(selectedColors)
-                          ) {
-                            return;
-                          }
-                          const imagesLoaded = drawRecolorPreview(
+                        onupdate: (canvasVnode) => {
+                          const key = JSON.stringify(selectedColors);
+                          if (canvasVnode.state.lastColorsKey === key) return;
+                          canvasVnode.state.lastColorsKey = key;
+                          const renderId =
+                            (canvasVnode.dom._recolorRenderId || 0) + 1;
+                          canvasVnode.dom._recolorRenderId = renderId;
+                          drawRecolorPreview(
                             itemId,
                             meta,
                             canvasVnode.dom,
                             selectedColors,
+                            renderId,
                           );
-                          if (imagesLoaded > 0) {
-                            rootViewNode.state.oldSelectedColors =
-                              JSON.stringify(selectedColors);
-                          }
+                        },
+                        onremove: (canvasVnode) => {
+                          canvasVnode.dom._recolorRenderId =
+                            (canvasVnode.dom._recolorRenderId || 0) + 1;
                         },
                       }),
                     ],

--- a/tests/canvas/palette-recolor-cache_spec.js
+++ b/tests/canvas/palette-recolor-cache_spec.js
@@ -1,0 +1,134 @@
+/**
+ * Tests for the bounded LRU recolor cache inside `getImageToDraw`.
+ *
+ * Invariants guarded:
+ * - Same (spritePath, recolors) returns the same cached canvas reference.
+ * - Different recolors produce different canvases (no false key collision).
+ * - `spritePath = null` bypasses cache (custom uploads, etc.).
+ * - `!recolors` short-circuits before cache (raw image returned).
+ * - `clearRecolorCache()` empties the cache.
+ * - Concurrent callers for the same key share one in-flight Promise.
+ */
+import { expect } from "chai";
+import { describe, it, beforeEach } from "mocha-globals";
+import {
+  getImageToDraw,
+  clearRecolorCache,
+} from "../../sources/canvas/palette-recolor.js";
+
+// Real item id from the dataset with a single recolor region.
+// `body` has type_name="body", recolors=[{material: "body"}].
+const RECOLOR_ITEM_ID = "body";
+
+function solidColorCanvas(r, g, b, w = 8, h = 8) {
+  const c = document.createElement("canvas");
+  c.width = w;
+  c.height = h;
+  const ctx = c.getContext("2d");
+  ctx.fillStyle = `rgb(${r},${g},${b})`;
+  ctx.fillRect(0, 0, w, h);
+  return c;
+}
+
+describe("canvas/palette-recolor.js recolor cache", () => {
+  beforeEach(() => {
+    clearRecolorCache();
+  });
+
+  it("returns the same canvas reference on cache hit (same spritePath + recolors)", async () => {
+    const img = solidColorCanvas(255, 0, 0);
+    const recolors = { body: "olive" };
+    const path = "spritesheets/body/bodies/male/walk.png";
+
+    const first = await getImageToDraw(img, RECOLOR_ITEM_ID, recolors, path);
+    const second = await getImageToDraw(img, RECOLOR_ITEM_ID, recolors, path);
+
+    expect(first).to.equal(second);
+  });
+
+  it("produces different canvases when recolors differ", async () => {
+    const img = solidColorCanvas(255, 0, 0);
+    const path = "spritesheets/body/bodies/male/walk.png";
+
+    const olive = await getImageToDraw(
+      img,
+      RECOLOR_ITEM_ID,
+      { body: "olive" },
+      path,
+    );
+    const bronze = await getImageToDraw(
+      img,
+      RECOLOR_ITEM_ID,
+      { body: "bronze" },
+      path,
+    );
+
+    expect(olive).to.not.equal(bronze);
+  });
+
+  it("produces different canvases when spritePath differs", async () => {
+    const img = solidColorCanvas(255, 0, 0);
+    const recolors = { body: "olive" };
+
+    const a = await getImageToDraw(
+      img,
+      RECOLOR_ITEM_ID,
+      recolors,
+      "spritesheets/body/bodies/male/walk.png",
+    );
+    const b = await getImageToDraw(
+      img,
+      RECOLOR_ITEM_ID,
+      recolors,
+      "spritesheets/body/bodies/male/slash.png",
+    );
+
+    expect(a).to.not.equal(b);
+  });
+
+  it("bypasses cache when spritePath is null (uncacheable inputs)", async () => {
+    const img = solidColorCanvas(255, 0, 0);
+    const recolors = { body: "olive" };
+
+    const first = await getImageToDraw(img, RECOLOR_ITEM_ID, recolors, null);
+    const second = await getImageToDraw(img, RECOLOR_ITEM_ID, recolors, null);
+
+    expect(first).to.not.equal(second);
+  });
+
+  it("returns the input image unchanged when recolors is null (no cache entry)", async () => {
+    const img = solidColorCanvas(255, 0, 0);
+    const path = "spritesheets/body/bodies/male/walk.png";
+
+    const result = await getImageToDraw(img, RECOLOR_ITEM_ID, null, path);
+
+    expect(result).to.equal(img);
+  });
+
+  it("clearRecolorCache() drops all entries so the next call recomputes", async () => {
+    const img = solidColorCanvas(255, 0, 0);
+    const recolors = { body: "olive" };
+    const path = "spritesheets/body/bodies/male/walk.png";
+
+    const first = await getImageToDraw(img, RECOLOR_ITEM_ID, recolors, path);
+    clearRecolorCache();
+    const second = await getImageToDraw(img, RECOLOR_ITEM_ID, recolors, path);
+
+    expect(first).to.not.equal(second);
+  });
+
+  it("concurrent callers for the same key resolve to the same canvas", async () => {
+    const img = solidColorCanvas(255, 0, 0);
+    const recolors = { body: "olive" };
+    const path = "spritesheets/body/bodies/male/walk.png";
+
+    const [a, b, c] = await Promise.all([
+      getImageToDraw(img, RECOLOR_ITEM_ID, recolors, path),
+      getImageToDraw(img, RECOLOR_ITEM_ID, recolors, path),
+      getImageToDraw(img, RECOLOR_ITEM_ID, recolors, path),
+    ]);
+
+    expect(a).to.equal(b);
+    expect(b).to.equal(c);
+  });
+});

--- a/tests/canvas/palette-recolor-merge_spec.js
+++ b/tests/canvas/palette-recolor-merge_spec.js
@@ -1,0 +1,137 @@
+/**
+ * Tests for the single-pass multi-palette merge — `recolorImage` now accepts
+ * an array of `{source, target}` mappings and applies them all in one pass.
+ *
+ * Exercised via `recolorImage` (CPU path forced). The WebGL path and CPU path
+ * share the same semantics; pixel-level correctness of the CPU implementation
+ * is sufficient to guard the packing logic against regressions.
+ */
+import { expect } from "chai";
+import { describe, it, before, after } from "mocha-globals";
+import {
+  recolorImage,
+  setPaletteRecolorMode,
+  getPaletteRecolorConfig,
+} from "../../sources/canvas/palette-recolor.js";
+
+function solidCanvas(r, g, b, w = 4, h = 4) {
+  const c = document.createElement("canvas");
+  c.width = w;
+  c.height = h;
+  const ctx = c.getContext("2d");
+  ctx.fillStyle = `rgb(${r},${g},${b})`;
+  ctx.fillRect(0, 0, w, h);
+  return c;
+}
+
+/** Two-color 4x4 canvas: left half color A, right half color B. */
+function splitCanvas(a, b) {
+  const c = document.createElement("canvas");
+  c.width = 4;
+  c.height = 4;
+  const ctx = c.getContext("2d");
+  ctx.fillStyle = `rgb(${a.r},${a.g},${a.b})`;
+  ctx.fillRect(0, 0, 2, 4);
+  ctx.fillStyle = `rgb(${b.r},${b.g},${b.b})`;
+  ctx.fillRect(2, 0, 2, 4);
+  return c;
+}
+
+function readPixel(canvas, x, y) {
+  const data = canvas.getContext("2d").getImageData(x, y, 1, 1).data;
+  return { r: data[0], g: data[1], b: data[2], a: data[3] };
+}
+
+describe("canvas/palette-recolor.js single-pass merge (CPU path)", () => {
+  let previousMode;
+
+  before(() => {
+    previousMode = getPaletteRecolorConfig().activeMode;
+    setPaletteRecolorMode("cpu");
+  });
+
+  after(() => {
+    if (previousMode === "webgl") setPaletteRecolorMode("webgl");
+  });
+
+  it("applies a single-mapping array (backward-compat shape)", () => {
+    const img = solidCanvas(255, 0, 0);
+    const mappings = [{ source: ["#FF0000"], target: ["#0000FF"] }];
+
+    const out = recolorImage(img, mappings);
+
+    const pixel = readPixel(out, 0, 0);
+    expect(pixel.r).to.equal(0);
+    expect(pixel.g).to.equal(0);
+    expect(pixel.b).to.equal(255);
+    expect(pixel.a).to.equal(255);
+  });
+
+  it("applies two palette mappings in one pass (no chaining)", () => {
+    // Source image: red on the left, green on the right.
+    const img = splitCanvas({ r: 255, g: 0, b: 0 }, { r: 0, g: 255, b: 0 });
+    const mappings = [
+      { source: ["#FF0000"], target: ["#0000FF"] }, // red → blue
+      { source: ["#00FF00"], target: ["#FFFF00"] }, // green → yellow
+    ];
+
+    const out = recolorImage(img, mappings);
+
+    const left = readPixel(out, 0, 0);
+    const right = readPixel(out, 3, 0);
+    expect(left).to.deep.include({ r: 0, g: 0, b: 255 });
+    expect(right).to.deep.include({ r: 255, g: 255, b: 0 });
+  });
+
+  it("leaves non-matching pixels unchanged", () => {
+    const img = solidCanvas(128, 64, 32);
+    const mappings = [{ source: ["#FF0000"], target: ["#0000FF"] }];
+
+    const out = recolorImage(img, mappings);
+
+    const pixel = readPixel(out, 0, 0);
+    expect(pixel.r).to.equal(128);
+    expect(pixel.g).to.equal(64);
+    expect(pixel.b).to.equal(32);
+  });
+
+  it("preserves alpha on transparent pixels (no recolor on alpha=0)", () => {
+    const c = document.createElement("canvas");
+    c.width = 4;
+    c.height = 4;
+    // Leave all pixels transparent.
+    const mappings = [{ source: ["#000000"], target: ["#FF00FF"] }];
+
+    const out = recolorImage(c, mappings);
+
+    const pixel = readPixel(out, 0, 0);
+    expect(pixel.a).to.equal(0);
+  });
+
+  it("handles an empty mappings array by leaving pixels unchanged", () => {
+    const img = solidCanvas(200, 100, 50);
+
+    const out = recolorImage(img, []);
+
+    const pixel = readPixel(out, 0, 0);
+    expect(pixel.r).to.equal(200);
+    expect(pixel.g).to.equal(100);
+    expect(pixel.b).to.equal(50);
+  });
+
+  it("preserves the first match in palette order when entries collide", () => {
+    // If two mappings in the concatenated list match the same source pixel,
+    // the shader/CPU returns on the FIRST match. This guards against someone
+    // inadvertently changing the early-return semantics.
+    const img = solidCanvas(255, 0, 0);
+    const mappings = [
+      { source: ["#FF0000"], target: ["#0000FF"] }, // first: red → blue
+      { source: ["#FF0000"], target: ["#00FF00"] }, // second (ignored): red → green
+    ];
+
+    const out = recolorImage(img, mappings);
+
+    const pixel = readPixel(out, 0, 0);
+    expect(pixel).to.deep.include({ r: 0, g: 0, b: 255 });
+  });
+});

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -10,6 +10,8 @@ import "./canvas/draw-frames_spec.js";
 import "./canvas/download_spec.js";
 import "./canvas/load-images_spec.js";
 import "./canvas/mask_spec.js";
+import "./canvas/palette-recolor-cache_spec.js";
+import "./canvas/palette-recolor-merge_spec.js";
 import "./canvas/renderer-issue-364_spec.js";
 import "./components/CollapsibleSection_spec.js";
 import "./components/FiltersPanel_spec.js";


### PR DESCRIPTION
## Summary

  Fixes [#418](https://github.com/LiberatedPixelCup/Universal-LPC-Spritesheet-Character-Generator/issues/418) (`renderCharacter` exceeding the 50ms slow-op threshold at ~195ms) with three independent changes to the palette recolor pipeline:

  - **Single-pass multi-palette shader** (`sources/canvas/webgl-palette-recolor.js`, `sources/canvas/palette-recolor.js`). `recolorImage` / `recolorImageWebGL` / `recolorImageCPU` / `createPaletteTexture` now accept `Array<{source, target}>` and pack all palette regions into one palette texture. Restores the "one layer = one shader pass" invariant that was broken when multi-region items (`heads_human_*`, `face_*`, `hair_long_tied`, …) started chaining 2 shader dispatches per
  item-animation. **We need to test if we are not adding collitions, because before we were chaining recolors, now we are recoloring at once** (specifically to confirm by @jrconway3 ).
  - **Bounded LRU recolor cache** (`sources/canvas/palette-recolor.js`). `getImageToDraw` now memoizes the recolored canvas keyed by `(spritePath, recolors)`, with cap 250 entries (~40MB worst case). Shared between the main canvas, tree
  previews, palette-select modal, and ZIP export. Stores the in-flight Promise so concurrent callers for the same key share one recolor. New `clearRecolorCache()` export for tests/runtime.
  - **Tree-preview guard race fix** (`sources/components/tree/ItemWithRecolors.js`). The previous `onupdate` guard was effectively dead code — `drawRecolorPreview` returns a `Promise`, and `if (imagesLoaded > 0)` coerces `Promise` to `NaN`, so the write that updated `oldSelectedColors` never executed. Every Mithril redraw re-ran a full recolor for every expanded tree item. Replaced with a synchronous `canvasVnode.state.lastColorsKey` guard (short-circuits duplicate draws) plus a `renderId` cancellation pattern (in-flight draws self-abort when a newer request supersedes them), mirroring the existing pattern in `PaletteSelectModal`.

Also adds `tests/canvas/palette-recolor-cache_spec.js` and `tests/canvas/palette-recolor-merge_spec.js` (13 new tests) to guard the cache invariants and single-pass packing against future regression.

  ### Measured effect

  Same character, change head, single-render comparison on localhost:

  | | before | after | delta |
  |---|---|---|---|
  | `renderCharacter` warm | 205ms | 122ms | **−40%** |
  | `renderCharacter` cold | 461ms | 143ms | **−69%** |
  | Total measurements / render | 143 | 61 | **−57%** |
  | `imageLoads` op count | 129 | 47 | **−64%** |
  | FPS | 81 | 104 | **+28%** |
  | usedJSHeapSize | 35 MB | 47 MB | +12 MB (cache) |
  | totalJSHeapSize | 92 MB | 64 MB | **−28 MB (less GC churn)** |

  ## Test plan

  - [ ] `npm run lint` clean
  - [ ] `npm run test:node` passes (77/77)
  - [ ] Browser tests pass (`npm test` or `node ./node_modules/testem/testem.js ci`) — 347/347 including 13 new palette-recolor tests
  - [ ] Visual smoke: main character renders correctly on first load (all cache misses)
  - [ ] Visual smoke: change body color — head + face skin update; hair / hat / shoes unchanged
  - [ ] Visual smoke: change eye color — eyes update on head + face; rest unchanged
  - [ ] Visual smoke: change head item — new head renders correctly
  - [ ] Visual smoke: palette-select modal shows correct variant thumbnails
  - [ ] Visual smoke: tree thumbnails match the main canvas for each item
  - [ ] Visual smoke: ZIP export produces identical output to pre-PR (recolor cache shouldn't affect export correctness, but worth spot-checking one export)
  - [ ] Rapid-interaction smoke: drag a color picker or rapidly switch selections — no stale colors sticking on tree thumbnails (validates renderId cancellation)