### PR TITLE
refactor: migrate custom-animations, fileName, helpers to typescript

### DIFF
--- a/scripts/generateSources/item-helper.mjs
+++ b/scripts/generateSources/item-helper.mjs
@@ -1,5 +1,5 @@
 import debugUtils from "../utils/debug.js";
-import { ucwords } from "../../sources/utils/helpers.js";
+import { ucwords } from "../../sources/utils/helpers.ts";
 import { paletteMetadata } from "./state.mjs";
 
 const { debugWarn } = debugUtils;

--- a/sources/canvas/draw-frames.ts
+++ b/sources/canvas/draw-frames.ts
@@ -1,18 +1,13 @@
 import { FRAME_SIZE } from "../state/constants.ts";
-import { animationRowsLayout } from "../custom-animations.js";
+import {
+  animationRowsLayout,
+  type CustomAnimationDefinition,
+} from "../custom-animations.ts";
 
 // Both HTMLImageElement and HTMLCanvasElement expose a numeric .height
 // and are accepted by CanvasRenderingContext2D.drawImage — the full API
 // surface this function uses, so it can treat them interchangeably.
 type SpriteSource = HTMLImageElement | HTMLCanvasElement;
-
-// TODO: custom-animations.js already declares this exact shape via JSDoc
-// typedef. Once that file converts to .ts, delete this local type and
-// import CustomAnimationDefinition from "../custom-animations.ts" instead.
-type CustomAnimationDefinition = {
-  frameSize: number;
-  frames: string[][];
-};
 
 export function drawFrameToFrame(
   destCtx: CanvasRenderingContext2D,

--- a/sources/canvas/preview-animation.js
+++ b/sources/canvas/preview-animation.js
@@ -4,7 +4,7 @@ import { FRAME_SIZE, ANIMATION_CONFIGS } from "../state/constants.ts";
 import { get2DContext, drawTransparencyBackground } from "./canvas-utils.js";
 import { applyTransparencyMaskToCanvas } from "./mask.ts";
 import { canvas } from "./renderer.js";
-import { customAnimations } from "../custom-animations.js";
+import { customAnimations } from "../custom-animations.ts";
 
 // Animation preview state
 let animationFrames = [1, 2, 3, 4, 5, 6, 7, 8]; // default for walk

--- a/sources/canvas/renderer.js
+++ b/sources/canvas/renderer.js
@@ -13,7 +13,7 @@ import {
   ANIMATION_OFFSETS,
   ANIMATION_CONFIGS,
 } from "../state/constants.ts";
-import { customAnimations, customAnimationBase } from "../custom-animations.js";
+import { customAnimations, customAnimationBase } from "../custom-animations.ts";
 import {
   setCurrentCustomAnimations,
   setCustomAnimYPositions,

--- a/sources/canvas/renderer.js
+++ b/sources/canvas/renderer.js
@@ -6,7 +6,7 @@ import { getSpritePath } from "../state/path.js";
 import { getImageToDraw } from "./palette-recolor.js";
 import { getMultiRecolors } from "../state/palettes.js";
 import { get2DContext, getZPos } from "./canvas-utils.js";
-import { variantToFilename } from "../utils/helpers.js";
+import { variantToFilename } from "../utils/helpers.ts";
 import { drawFramesToCustomAnimation } from "./draw-frames.ts";
 import {
   FRAME_SIZE,

--- a/sources/components/tree/BodyTypeSelector.js
+++ b/sources/components/tree/BodyTypeSelector.js
@@ -1,7 +1,7 @@
 // Body type selector component (styled as tree category)
 import { state } from "../../state/state.js";
 import { BODY_TYPES } from "../../state/constants.ts";
-import { capitalize } from "../../utils/helpers.js";
+import { capitalize } from "../../utils/helpers.ts";
 
 export const BodyTypeSelector = {
   oninit: function (vnode) {

--- a/sources/components/tree/ItemWithVariants.js
+++ b/sources/components/tree/ItemWithVariants.js
@@ -3,7 +3,7 @@ import classNames from "classnames";
 import { state, getSelectionGroup, selectItem } from "../../state/state.js";
 import { getLayersToLoad } from "../../state/meta.js";
 import { COMPACT_FRAME_SIZE, FRAME_SIZE } from "../../state/constants.ts";
-import { capitalize } from "../../utils/helpers.js";
+import { capitalize } from "../../utils/helpers.ts";
 
 export const ItemWithVariants = {
   view: function (vnode) {

--- a/sources/components/tree/PaletteSelectModal.js
+++ b/sources/components/tree/PaletteSelectModal.js
@@ -3,7 +3,7 @@ import classNames from "classnames";
 import { drawRecolorPreview } from "../../canvas/palette-recolor.js";
 import * as catalog from "../../state/catalog.js";
 import { state, getSelectionGroup } from "../../state/state.js";
-import { ucwords } from "../../utils/helpers.js";
+import { ucwords } from "../../utils/helpers.ts";
 import { COMPACT_FRAME_SIZE, FRAME_SIZE } from "../../state/constants.ts";
 
 /**

--- a/sources/components/tree/TreeNode.js
+++ b/sources/components/tree/TreeNode.js
@@ -10,7 +10,7 @@ import {
   capitalize,
   matchesSearch,
   nodeHasMatches,
-} from "../../utils/helpers.js";
+} from "../../utils/helpers.ts";
 import { ItemWithVariants } from "./ItemWithVariants.js";
 import { ItemWithRecolors } from "./ItemWithRecolors.js";
 

--- a/sources/custom-animations.ts
+++ b/sources/custom-animations.ts
@@ -1,8 +1,6 @@
-/**
- * @typedef {Record<string, number>} AnimationRowsLayout
- * @type {AnimationRowsLayout}
- */
-const animationRowsLayout = {
+export type AnimationRowsLayout = Record<string, number>;
+
+const animationRowsLayout: AnimationRowsLayout = {
   "thrust-n": 3,
   "thrust-w": 4,
   "thrust-s": 5,
@@ -29,11 +27,13 @@ const animationRowsLayout = {
   "sit-e": 32,
 };
 
-/**
- * @typedef {{frameSize: number, frames: string[][]}} CustomAnimationDefinition
- * @type {Record<string, CustomAnimationDefinition>}
- */
-const customAnimations = {
+export type CustomAnimationDefinition = {
+  frameSize: number;
+  frames: string[][];
+  skipFirstFrameInPreview?: boolean;
+};
+
+const customAnimations: Record<string, CustomAnimationDefinition> = {
   wheelchair: {
     frameSize: 64,
     frames: [
@@ -553,21 +553,20 @@ const customAnimations = {
   },
 };
 
-/**
- *
- * @param {CustomAnimationDefinition} customAnimation
- * @returns {{width:number, height:number}}
- */
-const customAnimationSize = (customAnimation) => ({
+const customAnimationSize = (
+  customAnimation: CustomAnimationDefinition,
+): { width: number; height: number } => ({
   width: customAnimation.frameSize * customAnimation.frames[0].length,
   height: customAnimation.frameSize * customAnimation.frames.length,
 });
 
-const customAnimationBase = (custAnim) =>
+const customAnimationBase = (custAnim: CustomAnimationDefinition): string =>
   custAnim.frames[0][0].split(",")[0].split("-")[0];
 
-const isCustomAnimationBasedOnStandardAnimation = (custAnim, stdAnimName) =>
-  customAnimationBase(custAnim) === stdAnimName;
+const isCustomAnimationBasedOnStandardAnimation = (
+  custAnim: CustomAnimationDefinition,
+  stdAnimName: string,
+): boolean => customAnimationBase(custAnim) === stdAnimName;
 
 // Expose for use in other scripts
 export {

--- a/sources/state/filters.js
+++ b/sources/state/filters.js
@@ -1,4 +1,4 @@
-import { customAnimationBase, customAnimations } from "../custom-animations.js";
+import { customAnimationBase, customAnimations } from "../custom-animations.ts";
 import { LICENSE_CONFIG, ANIMATIONS } from "./constants.ts";
 import * as catalog from "./catalog.js";
 import { state } from "./state.js";

--- a/sources/state/meta.js
+++ b/sources/state/meta.js
@@ -1,5 +1,5 @@
 import { getZPos } from "../canvas/canvas-utils.js";
-import { variantToFilename } from "../utils/helpers.js";
+import { variantToFilename } from "../utils/helpers.ts";
 import { replaceInPath } from "./path.js";
 import * as catalog from "./catalog.js";
 

--- a/sources/state/path.js
+++ b/sources/state/path.js
@@ -2,7 +2,7 @@ import "../install-item-metadata.js";
 import { ANIMATIONS } from "./constants.ts";
 import { getHashParamsforSelections } from "./hash.js";
 import * as catalog from "./catalog.js";
-import { variantToFilename, es6DynamicTemplate } from "../utils/helpers.js";
+import { variantToFilename, es6DynamicTemplate } from "../utils/helpers.ts";
 import { debugLog } from "../utils/debug.js";
 
 // Dependency injection for testability (see setPathDeps / resetPathDeps)

--- a/sources/state/zip.js
+++ b/sources/state/zip.js
@@ -16,7 +16,7 @@ import {
   addedCustomAnimations,
 } from "../canvas/renderer.js";
 import { getMultiRecolors } from "./palettes.js";
-import { getItemFileName } from "../utils/fileName.js";
+import { getItemFileName } from "../utils/fileName.ts";
 import { loadImage } from "../canvas/load-image.js";
 import { getImageToDraw } from "../canvas/palette-recolor.js";
 import { customAnimations, customAnimationSize } from "../custom-animations.ts";

--- a/sources/state/zip.js
+++ b/sources/state/zip.js
@@ -19,7 +19,7 @@ import { getMultiRecolors } from "./palettes.js";
 import { getItemFileName } from "../utils/fileName.js";
 import { loadImage } from "../canvas/load-image.js";
 import { getImageToDraw } from "../canvas/palette-recolor.js";
-import { customAnimations, customAnimationSize } from "../custom-animations.js";
+import { customAnimations, customAnimationSize } from "../custom-animations.ts";
 import { getSortedLayersWithCustomFallback } from "./meta.js";
 import { canvasToBlob } from "../canvas/canvas-utils.js";
 import {

--- a/sources/utils/credits.js
+++ b/sources/utils/credits.js
@@ -3,7 +3,7 @@
 import * as catalog from "../state/catalog.js";
 import { state } from "../state/state.js";
 import { replaceInPath } from "../state/path.js";
-import { variantToFilename } from "../utils/helpers.js";
+import { variantToFilename } from "../utils/helpers.ts";
 
 /**
  * Helper function to collect credits from all selected items

--- a/sources/utils/fileName.ts
+++ b/sources/utils/fileName.ts
@@ -1,23 +1,27 @@
 import * as catalog from "../state/catalog.js";
 
-function addExtensionIfMissing(filename, extension) {
+// TODO: catalog.js currently returns `object | undefined` from
+// getItemMerged (JSDoc-erased shape). When catalog.js converts to .ts
+// and the generator output shapes it manages are typed, delete these
+// local narrowings and use the real exported type instead.
+type ItemLayerMeta = { zPos?: number };
+type ItemMergedShape = { layers?: Record<string, ItemLayerMeta | undefined> };
+
+function addExtensionIfMissing(filename: string, extension: string): string {
   if (filename.toLowerCase().endsWith(extension.toLowerCase())) {
     return filename;
   }
   return `${filename}.${extension}`;
 }
 
-/**
- * Helper function to get item filename with zPos prefix
- */
 export function getItemFileName(
-  itemId,
-  variant,
-  name,
-  layerNum = 1,
-  zOverride = null,
-) {
-  const meta = catalog.getItemMerged(itemId);
+  itemId: string,
+  variant: string,
+  name: string,
+  layerNum: number = 1,
+  zOverride?: number,
+): string {
+  const meta = catalog.getItemMerged(itemId) as ItemMergedShape | undefined;
   if (!meta) return addExtensionIfMissing(name, "png");
 
   // Get zPos from specified layer
@@ -27,7 +31,7 @@ export function getItemFileName(
       "Requested layer number " + layerNum + " not found for item: " + itemId,
     );
   const zPos = zOverride || layer?.zPos || 100;
-  const altName = `${itemId}_${variant ?? ""}`;
+  const altName = `${itemId}_${variant}`;
 
   // Format: "050 body_male_light" (zPos padded to 3 digits + space + name)
   const safeName = (name || altName).replace(/[^a-z0-9.]/gi, "_").toLowerCase();

--- a/sources/utils/helpers.ts
+++ b/sources/utils/helpers.ts
@@ -1,16 +1,29 @@
 // Pure utility functions with minimal catalog reads for tree search
 import * as catalog from "../state/catalog.js";
 
+// TODO: catalog.js currently returns `object | undefined` from
+// getItemLite (JSDoc-erased shape). When catalog.js converts to .ts
+// and the generator output shapes it manages are typed, delete this
+// local narrowing and use the real exported type instead.
+type ItemLiteShape = { name?: string };
+
+// Tree shape used by nodeHasMatches. Recursive structure mirrors how
+// categoryTree nodes are organized in the generator output.
+type CategoryTreeNode = {
+  items?: string[];
+  children?: Record<string, CategoryTreeNode>;
+};
+
 /**
  * Simple ES6 template string replacement
  * e.g. es6DynamicTemplate("Hello ${name}", {name: "World"}) => "Hello World"
  * Note: does not support complex expressions, only simple variable replacement
- * @param {string} templateString - Template string with ${var} placeholders
- * @param {Object} templateVariables - Object with variable values
- * @returns {string} - Resulting string with variables replaced
  */
 // copied from https://github.com/mikemaccana/dynamic-template/blob/046fee36aecc1f48cf3dc454d9d36bb0e96e0784/index.js
-export const es6DynamicTemplate = (templateString, templateVariables) =>
+export const es6DynamicTemplate = (
+  templateString: string,
+  templateVariables: Record<string, string>,
+): string =>
   templateString.replace(
     /\${(.*?)}/g,
     (_, g) => templateVariables[g] ?? `\${${g}}`,
@@ -18,42 +31,29 @@ export const es6DynamicTemplate = (templateString, templateVariables) =>
 
 /**
  * Convert variant name to filename format (spaces to underscores)
- * @param {string} variant - Variant name (e.g., "light brown")
- * @returns {string} - Filename format (e.g., "light_brown")
+ * e.g. "light brown" → "light_brown"
  */
-export function variantToFilename(variant) {
+export function variantToFilename(variant: string): string {
   return variant.replaceAll(" ", "_");
 }
 
-/**
- * Helper function to capitalize strings for display
- */
-export function capitalize(str) {
+export function capitalize(str: string): string {
   return str.charAt(0).toUpperCase() + str.slice(1);
 }
 
-/**
- * Helper function to capitalize all words in a string for display
- */
-export function ucwords(str) {
+export function ucwords(str: string): string {
   return str
     .split(" ")
     .map((word) => capitalize(word))
     .join(" ");
 }
 
-/**
- * Helper function to check if item matches search query
- */
-export function matchesSearch(text, query) {
+export function matchesSearch(text: string, query: string): boolean {
   if (!query || query.length < 2) return true;
   return text.toLowerCase().includes(query.toLowerCase());
 }
 
-/**
- * Helper function to check if a node or its children contain search matches
- */
-export function nodeHasMatches(node, query) {
+export function nodeHasMatches(node: CategoryTreeNode, query: string): boolean {
   if (!query || query.length < 2) return true;
 
   // Until lite metadata is registered we cannot match item names; keep nodes visible
@@ -65,8 +65,8 @@ export function nodeHasMatches(node, query) {
   if (
     node.items &&
     node.items.some((itemId) => {
-      const meta = catalog.getItemLite(itemId);
-      return meta && matchesSearch(meta.name, query);
+      const meta = catalog.getItemLite(itemId) as ItemLiteShape | undefined;
+      return meta?.name != null && matchesSearch(meta.name, query);
     })
   ) {
     return true;

--- a/sources/utils/zip-helpers.js
+++ b/sources/utils/zip-helpers.js
@@ -5,7 +5,7 @@ import {
   DIRECTIONS,
 } from "../state/constants.ts";
 import { drawFramesToCustomAnimation } from "../canvas/draw-frames.ts";
-import { customAnimationSize } from "../custom-animations.js";
+import { customAnimationSize } from "../custom-animations.ts";
 import {
   canvasToBlob,
   get2DContext,

--- a/tests/state/path_spec.js
+++ b/tests/state/path_spec.js
@@ -10,7 +10,7 @@ import {
   resetCatalogForTests,
 } from "../../sources/state/catalog.js";
 import { restoreAppCatalogAfterTest } from "../browser-catalog-fixture.js";
-import { es6DynamicTemplate } from "../../sources/utils/helpers.js";
+import { es6DynamicTemplate } from "../../sources/utils/helpers.ts";
 import { expect } from "chai";
 import sinon from "sinon";
 import { describe, it, beforeEach, afterEach } from "mocha-globals";

--- a/tests/state/zip_spec.js
+++ b/tests/state/zip_spec.js
@@ -13,7 +13,7 @@ import {
   addAnimationToZipFolder,
   addStandardAnimationToZipCustomFolder,
 } from "../../sources/utils/zip-helpers.js";
-import { getItemFileName } from "../../sources/utils/fileName.js";
+import { getItemFileName } from "../../sources/utils/fileName.ts";
 import { getSortedLayers } from "../../sources/state/meta.js";
 import {
   exportIndividualFrames,

--- a/tests/utils/fileName_spec.js
+++ b/tests/utils/fileName_spec.js
@@ -5,7 +5,7 @@ import {
   restoreAppCatalogAfterTest,
   seedBrowserCatalog,
 } from "../browser-catalog-fixture.js";
-import { getItemFileName } from "../../sources/utils/fileName.js";
+import { getItemFileName } from "../../sources/utils/fileName.ts";
 
 describe("getItemFileName", () => {
   beforeEach(() => {

--- a/tests/utils/helpers_spec.js
+++ b/tests/utils/helpers_spec.js
@@ -11,9 +11,9 @@ import {
   capitalize,
   matchesSearch,
   nodeHasMatches,
-} from "../../sources/utils/helpers.js";
+} from "../../sources/utils/helpers.ts";
 
-describe("utils/helpers.js", () => {
+describe("utils/helpers.ts", () => {
   describe("es6DynamicTemplate", () => {
     it("should replace variables in the template string with values from the object", () => {
       const template = "Hello ${name}, welcome to ${place}!";

--- a/tests/utils/zip-helpers_spec.js
+++ b/tests/utils/zip-helpers_spec.js
@@ -4,7 +4,7 @@ import { describe, it, beforeEach, afterEach } from "mocha-globals";
 import {
   customAnimations,
   customAnimationSize,
-} from "../../sources/custom-animations.js";
+} from "../../sources/custom-animations.ts";
 import {
   addAnimationToZipFolder,
   addCharacterJsonAndCredits,


### PR DESCRIPTION
Third round of the gradual TS migration. Converts three pure-leaf files to .ts and resolves one cross-file type duplication left by the previous PR.

  ## Conversions

  ### sources/custom-animations.js → .ts

  Promoted the two JSDoc typedefs to exported TS types:
  - `AnimationRowsLayout = Record<string, number>`
  - `CustomAnimationDefinition = { frameSize; frames; skipFirstFrameInPreview? }`

  The `skipFirstFrameInPreview?: boolean` field was surfaced by the type-check: it's present on `walk_128` and consumed by `sources/canvas/preview-animation.js:38`, but the JSDoc typedef didn't declare it. The declared shape now matches the data.

  Five exports typed: `animationRowsLayout`, `customAnimations`, `customAnimationSize`, `customAnimationBase`, `isCustomAnimationBasedOnStandardAnimation`.

  Also resolved the TODO left in `draw-frames.ts` from the previous PR: removed the local `type CustomAnimationDefinition` duplicate and imported it from `custom-animations.ts` via the inline `type` keyword syntax. No more duplication of that shape.

  ### sources/utils/fileName.js → .ts

  Single export `getItemFileName` typed with a cleaned-up signature:

  ```ts
  export function getItemFileName(
    itemId: string,
    variant: string,
    name: string,
    layerNum: number = 1,
    zOverride?: number,
  ): string

  Added a local ItemMergedShape cast over catalog.getItemMerged's return. catalog.js JSDoc-declares its return as bare object | undefined; the local narrowing lets call sites access .layers?.[...]?.zPos without a TS error. Inline TODO comment points to where this cast should be deleted (when catalog.js converts).

  sources/utils/helpers.js → .ts

  Six exports typed: es6DynamicTemplate, variantToFilename, capitalize, ucwords, matchesSearch, nodeHasMatches. Defined a local CategoryTreeNode type for the recursive tree shape used by nodeHasMatches.

  Same local-cast + TODO pattern over catalog.getItemLite's object | undefined return (via ItemLiteShape).