### PR TITLE
fix (sass): quiet deps flag

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -61,6 +61,10 @@ export default defineConfig(({ command }) => ({
   },
   css: {
     target: false,
+    preprocessorOptions: {
+      scss: { quietDeps: true },
+      sass: { quietDeps: true },
+    },
   },
   plugins: [
     vitePluginPreviewServeDistSpritesheets(),


### PR DESCRIPTION
This flag quiets sass warnings from our dependencies, but not from our own code.

This silences the sass deprecation warnings you see from bulma.