### PR TITLE
docs: document 64x64 and oversize frame dimensions

### DIFF
--- a/.auto-pr/SPEC.md
+++ b/.auto-pr/SPEC.md
@@ -1,0 +1,10 @@
+# Spec - Issue #167
+
+## Problem
+
+The project documentation does not explicitly tell users that the classic LPC frame size is 64x64 while some weapon and oversize animations require larger frame dimensions.
+
+## Acceptance Criteria
+
+- [x] The README explicitly states that classic LPC frames are 64x64.
+- [x] The README clarifies that weapon and oversize animations can exceed 64x64 and should be cut/exported with matching larger frame dimensions.

--- a/.auto-pr/TODO.md
+++ b/.auto-pr/TODO.md
@@ -1,0 +1,5 @@
+# TODO - Issue #167
+
+- [x] Locate the existing animation/frame guidance in the README.
+- [x] Add a short note clarifying when 64x64 applies and when oversize frame dimensions are needed.
+- [x] Run minimal documentation validation.

--- a/.auto-pr/VALIDATION.md
+++ b/.auto-pr/VALIDATION.md
@@ -1,0 +1,1 @@
+- [x] Reviewed the updated README text and verified the added note sits next to the animation frame guidance.

--- a/README.md
+++ b/README.md
@@ -82,6 +82,8 @@ You can look at [the Animation Guide in Eliza's repository](https://github.com/E
 
 Also, each animation has a frame cycle documented which you can see next to the animation preview.
 
+The classic LPC frame size is `64x64`, but some weapon and oversize animations extend beyond that box. If you export or cut frames for those animations, choose the matching oversize frame dimensions instead of assuming every frame is `64x64`.
+
 ### Run This Project Locally for Development
 
 The UI is built with [Vite](https://vitejs.dev/). Use a dev server rather than opening `index.html` as a `file://` URL, since ES modules and asset paths expect HTTP and modern browsers restrict file URLs.


### PR DESCRIPTION
## Summary

Fixes #167 - _Document frame sizes_

## Spec

# Spec - Issue #167

## Problem

The project documentation does not explicitly tell users that the classic LPC frame size is 64x64 while some weapon and oversize animations require larger frame dimensions.

## Acceptance Criteria

- [x] The README explicitly states that classic LPC frames are 64x64.
- [x] The README clarifies that weapon and oversize animations can exceed 64x64 and should be cut/exported with matching larger frame dimensions.

## Work Breakdown

# TODO - Issue #167

- [x] Locate the existing animation/frame guidance in the README.
- [x] Add a short note clarifying when 64x64 applies and when oversize frame dimensions are needed.
- [x] Run minimal documentation validation.

## Notes

_None._

## Validation

- [x] Reviewed the updated README text and verified the added note sits next to the animation frame guidance.
