### PR TITLE
* Fixed Vendor Globals On Static (Non-Vite) Contexts

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,8 @@
 {
   "type": "module",
   "sideEffects": [
-    "sources/state/catalog.ts"
+    "sources/state/catalog.ts",
+    "sources/vendor-globals.js"
   ],
   "name": "universal-lpc-spritesheet-character-generator",
   "version": "0.0.0",


### PR DESCRIPTION
resolves #463 

I confirmed this locally:

I have a standalone local version of the ULPC Generator running on my own XAMPP. When I run it using `npm run dev`, the JSZip library works fine. When I run it off of my localhost, I get the same error. After adding this fix (Copilot helped me):
```
  "sideEffects": [
    "sources/state/catalog.ts",
    "sources/vendor-globals.js"
  ],
```

Adding `sources/vendor-globals.js` to `sideEffects` fixes the issue here, so I suspect it'll work on the deploy as well, but I can't confirm. All I can confirm is that I was able to reproduce the error locally, and once I added this fix, it now did work locally.