### PR TITLE
Custom image cleanup

### DIFF
--- a/sources/canvas/renderer.ts
+++ b/sources/canvas/renderer.ts
@@ -4,7 +4,7 @@
 import { ok, err, type Result } from "neverthrow";
 import { loadImage, loadImagesInParallel } from "./load-image.ts";
 import type { LoadedImage } from "./load-image.ts";
-import { getSpritePath } from "../state/path.ts";
+import { getSpritePath, type PathError } from "../state/path.ts";
 import { getImageToDraw } from "./palette-recolor.ts";
 import { getMultiRecolors } from "../state/palettes.ts";
 import { get2DContext, getZPos } from "./canvas-utils.ts";
@@ -22,7 +22,11 @@ import {
 } from "./preview-animation.ts";
 import { getSortedLayersByAnim } from "../state/meta.ts";
 import type { AnimationLayer } from "../state/meta.ts";
-import { catalogReady, getItemMerged } from "../state/catalog.ts";
+import {
+  catalogReady,
+  formatLoadError,
+  getItemMerged,
+} from "../state/catalog.ts";
 import m from "mithril";
 import { debugWarn } from "../utils/debug.ts";
 import type { Selections } from "../state/state.ts";
@@ -48,11 +52,25 @@ const animationConfigByName = ANIMATION_CONFIGS as Record<
   AnimationConfig | undefined
 >;
 
+function formatPathError(itemId: string, e: PathError): string {
+  switch (e.kind) {
+    case "loading":
+    case "not-found":
+      return `getSpritePath: ${formatLoadError(e)} (item ${itemId})`;
+    case "missing-layer":
+      return `getSpritePath: item ${itemId} has no layer ${e.layerNum}`;
+    case "missing-bodytype-path":
+      return `getSpritePath: item ${itemId} has no path for bodyType ${e.bodyType}`;
+  }
+}
+
 /**
- * A standard-animation sprite item collected during `runRenderCharacter`. The
- * `customImage` variant (used for the user-uploaded sprite) carries an
- * already-loaded `HTMLImageElement` and has `spritePath: null`; everything else
- * resolves a path through `getSpritePath`.
+ * A standard-animation sprite item collected during `runRenderCharacter`.
+ *
+ * Invariant: `spritePath === null` iff `customImage !== undefined`. The
+ * customImage variant (user-uploaded sprite) carries an already-loaded
+ * `HTMLImageElement`; everything else resolves a path through `getSpritePath`.
+ * On `getSpritePath` err the entry is skipped (not pushed with a null path).
  */
 export type ItemToDraw = {
   itemId: string;
@@ -322,7 +340,7 @@ async function runRenderCharacter(
             if (!meta.animations.includes(animName)) continue;
           }
 
-          const spritePath = getSpritePath(
+          const pathResult = getSpritePath(
             itemId,
             variant ?? null,
             recolors,
@@ -331,14 +349,18 @@ async function runRenderCharacter(
             layerNum,
             selections,
             meta,
-          ).unwrapOr(null);
+          );
+          if (pathResult.isErr()) {
+            debugWarn(formatPathError(itemId, pathResult.error));
+            continue;
+          }
 
           itemsToDraw.push({
             itemId,
             name: selection.name,
             variant: variant ?? null,
             recolors,
-            spritePath,
+            spritePath: pathResult.value,
             zPos,
             layerNum,
             animation: animName,
@@ -766,7 +788,7 @@ export async function renderSingleItem(
     itemId: string;
     variant: string | null;
     recolors: Recolors;
-    spritePath: string | null;
+    spritePath: string;
     zPos: number;
     layerNum: number;
     animation: string;
@@ -798,7 +820,7 @@ export async function renderSingleItem(
         if (!meta.animations.includes(animName)) continue;
       }
 
-      const spritePath = getSpritePath(
+      const pathResult = getSpritePath(
         itemId,
         variant,
         recolors,
@@ -807,13 +829,17 @@ export async function renderSingleItem(
         layerNum,
         selections,
         meta,
-      ).unwrapOr(null);
+      );
+      if (pathResult.isErr()) {
+        debugWarn(formatPathError(itemId, pathResult.error));
+        continue;
+      }
 
       spritesToDraw.push({
         itemId,
         variant,
         recolors,
-        spritePath,
+        spritePath: pathResult.value,
         zPos,
         layerNum,
         animation: animName,
@@ -916,7 +942,7 @@ export async function renderSingleItemAnimation(
 
   // Build list of sprites to draw for this item & animation
   type AnimSprite = {
-    spritePath: string | null;
+    spritePath: string;
     zPos: number;
     layerNum: number;
     recolors: Recolors;
@@ -945,7 +971,7 @@ export async function renderSingleItemAnimation(
       if (!meta.animations.includes(animationName)) continue;
     }
 
-    const spritePath = getSpritePath(
+    const pathResult = getSpritePath(
       itemId,
       variant,
       recolors,
@@ -954,10 +980,14 @@ export async function renderSingleItemAnimation(
       layerNum,
       selections,
       meta,
-    ).unwrapOr(null);
+    );
+    if (pathResult.isErr()) {
+      debugWarn(formatPathError(itemId, pathResult.error));
+      continue;
+    }
 
     spritesToDraw.push({
-      spritePath,
+      spritePath: pathResult.value,
       zPos,
       layerNum,
       recolors,

--- a/sources/canvas/renderer.ts
+++ b/sources/canvas/renderer.ts
@@ -65,36 +65,31 @@ function formatPathError(itemId: string, e: PathError): string {
 }
 
 /**
- * A standard-animation sprite item collected during `runRenderCharacter`.
- *
- * Invariant: `spritePath === null` iff `customImage !== undefined`. The
- * customImage variant (user-uploaded sprite) carries an already-loaded
- * `HTMLImageElement`; everything else resolves a path through `getSpritePath`.
- * On `getSpritePath` err the entry is skipped (not pushed with a null path).
+ * Where the bytes for a drawable layer come from. The two cases converge on
+ * `HTMLImageElement`: `catalog` items resolve a URL via `getSpritePath` and
+ * fetch through `loadImage`; `custom` items carry the already-decoded image
+ * from the user's file upload.
  */
-export type ItemToDraw = {
+export type LayerSource =
+  | { kind: "catalog"; spritePath: string }
+  | { kind: "custom"; image: HTMLImageElement };
+
+/**
+ * One queued draw operation produced by `runRenderCharacter`: one `(item,
+ * layer, animation)` triple, corresponding 1:1 with a `drawImage` call in the
+ * draw loop. The exported `drawCalls` array is `DrawCall[]`.
+ */
+export type DrawCall = {
   itemId: string;
   name?: string;
   variant: string | null;
   recolors?: Recolors;
-  spritePath: string | null;
   zPos: number;
   layerNum: number;
   animation: string;
   yPos: number;
-  isCustom: boolean;
   needsRecolor?: boolean;
-  customImage?: HTMLImageElement;
-};
-
-/**
- * One entry in the exported `layers` array — deduplicated by `(itemId, layerNum)`
- * across all standard animations of `itemsToDraw`. Consumers: `state/zip.ts`,
- * `components/download/Download.js`, and tests.
- */
-export type RenderedLayer = Omit<ItemToDraw, "spritePath" | "animation"> & {
-  fileName: string;
-  supportedAnimations: string[];
+  source: LayerSource;
 };
 
 type CustomAnimationItem = {
@@ -106,7 +101,6 @@ type CustomAnimationItem = {
   zPos: number;
   layerNum: number;
   customAnimation: string;
-  isCustom: true;
 };
 
 type CustomSpriteAreaItem = {
@@ -123,7 +117,7 @@ type CustomSpriteAreaItem = {
 type ExtractedFramesAreaItem = {
   type: "extracted_frames";
   zPos: number;
-  spritePath: string | null;
+  spritePath: string;
   itemId: string;
   animation: string;
   needsRecolor?: boolean;
@@ -158,8 +152,7 @@ export const SHEET_WIDTH = 832; // 13 frames * 64px
 
 export let canvas: HTMLCanvasElement | null = null;
 export let ctx: CanvasRenderingContext2D | null = null;
-export let layers: RenderedLayer[] = [];
-export let itemsToDraw: ItemToDraw[] = [];
+export let drawCalls: DrawCall[] = [];
 export let addedCustomAnimations: Set<string> = new Set();
 export let customAreaItems: Record<string, CustomAreaItem[]> = {};
 /** True after `initCanvas()` — offscreen buffer exists (main bootstrap runs this after S1∧S2). */
@@ -230,8 +223,8 @@ async function runRenderCharacter(
 ): Promise<void> {
   const profiler = window.profiler;
 
-  // Build list of items to draw
-  itemsToDraw = [];
+  // Build list of draw calls
+  drawCalls = [];
   addedCustomAnimations = new Set(); // Track which custom animations we've added
 
   // Import state to access custom uploaded image (kept out of `renderCharacter` profile span)
@@ -307,7 +300,6 @@ async function runRenderCharacter(
             zPos,
             layerNum,
             customAnimation: customAnimName,
-            isCustom: true,
           });
 
           continue; // Skip standard animation processing for this layer
@@ -355,65 +347,42 @@ async function runRenderCharacter(
             continue;
           }
 
-          itemsToDraw.push({
+          drawCalls.push({
             itemId,
             name: selection.name,
             variant: variant ?? null,
             recolors,
-            spritePath: pathResult.value,
+            source: { kind: "catalog", spritePath: pathResult.value },
             zPos,
             layerNum,
             animation: animName,
             yPos,
-            isCustom: false,
             needsRecolor: itemId === "body-body" && variant !== "light", // Flag body variants for recoloring
           });
         }
       }
     }
 
-    // Add custom uploaded image to itemsToDraw if present
+    // Add custom uploaded image as a draw call if present
     if (appState.customUploadedImage) {
+      const customImage = appState.customUploadedImage;
       // Add custom image to be drawn at all standard animation positions
       for (const [animName, yPos] of Object.entries(ANIMATION_OFFSETS)) {
-        itemsToDraw.push({
+        drawCalls.push({
           itemId: "custom-upload",
           variant: null,
-          spritePath: null, // Will draw directly from Image object
+          source: { kind: "custom", image: customImage },
           zPos: appState.customImageZPos,
           layerNum: 0,
           animation: animName,
           yPos,
-          isCustom: false,
-          customImage: appState.customUploadedImage, // Store the Image object
         });
       }
     }
 
-    // Sort standard items by zPos only (lower zPos = drawn first = behind)
-    // This ensures shadow (zPos=0) is drawn before body (zPos=10), etc.
-    itemsToDraw.sort((a, b) => a.zPos - b.zPos);
-
-    // save layers for external access — dedupe by (itemId, layerNum), collecting
-    // all `animation` values into `supportedAnimations`.
-    layers = itemsToDraw.reduce<RenderedLayer[]>((acc, item) => {
-      const existing = acc.find(
-        (l) => l.itemId === item.itemId && l.layerNum === item.layerNum,
-      );
-      if (existing) {
-        existing.supportedAnimations.push(item.animation);
-        return acc;
-      }
-      const { spritePath, animation, ...rest } = item;
-      acc.push({
-        ...rest,
-        fileName: spritePath
-          ? spritePath.substring("spritesheets/".length)
-          : "",
-        supportedAnimations: [animation],
-      });
-      return acc;
-    }, []);
+    // Sort by zPos (lower zPos = drawn first = behind). Shadow (zPos=0) before
+    // body (zPos=10), etc.
+    drawCalls.sort((a, b) => a.zPos - b.zPos);
 
     // Calculate total canvas height needed (standard sheet + custom animations)
     let totalHeight = SHEET_HEIGHT;
@@ -467,23 +436,22 @@ async function runRenderCharacter(
     setCustomAnimYPositions(customAnimYPositions);
 
     // Load all standard animation images in parallel and attach them to their items
-    const loadPromises = itemsToDraw.map((item) => {
-      if (item.customImage) {
-        // Custom image already loaded
-        return Promise.resolve({ item, img: item.customImage, success: true });
-      } else {
-        // Load standard image
-        return loadImage(item.spritePath!)
-          .then((img) => ({ item, img, success: true }))
-          .catch(() => {
-            debugWarn(`Failed to load sprite: ${item.spritePath}`);
-            return {
-              item,
-              img: null as HTMLImageElement | null,
-              success: false,
-            };
-          });
+    const loadPromises = drawCalls.map((item) => {
+      if (item.source.kind === "custom") {
+        // Already-decoded user-uploaded image
+        return Promise.resolve({ item, img: item.source.image, success: true });
       }
+      const { spritePath } = item.source;
+      return loadImage(spritePath)
+        .then((img) => ({ item, img, success: true }))
+        .catch(() => {
+          debugWarn(`Failed to load sprite: ${spritePath}`);
+          return {
+            item,
+            img: null as HTMLImageElement | null,
+            success: false,
+          };
+        });
     });
 
     const loadedItems = await Promise.all(loadPromises);
@@ -495,7 +463,7 @@ async function runRenderCharacter(
           img,
           item.itemId,
           item.recolors,
-          item.spritePath,
+          item.source.kind === "catalog" ? item.source.spritePath : null,
         );
         renderCtx.drawImage(imageToDraw, 0, item.yPos);
       }
@@ -536,14 +504,15 @@ async function runRenderCharacter(
         }
 
         // 2. Add standard items that need to be extracted into this custom animation
-        // (e.g., body "sit" frames go into wheelchair custom animation)
+        // (e.g., body "sit" frames go into wheelchair custom animation).
+        // Custom-source items have no spritePath to extract frames from, so skip them.
         if (baseAnim) {
-          for (const item of itemsToDraw) {
-            if (item.animation === baseAnim) {
+          for (const item of drawCalls) {
+            if (item.animation === baseAnim && item.source.kind === "catalog") {
               areaItems.push({
                 type: "extracted_frames",
                 zPos: item.zPos,
-                spritePath: item.spritePath,
+                spritePath: item.source.spritePath,
                 itemId: item.itemId,
                 animation: item.animation,
                 needsRecolor: item.needsRecolor,

--- a/sources/components/download/Download.ts
+++ b/sources/components/download/Download.ts
@@ -1,7 +1,7 @@
 // Download component
 import m from "mithril";
 import { state } from "../../state/state.ts";
-import { layers } from "../../canvas/renderer.ts";
+import { drawCalls } from "../../canvas/renderer.ts";
 import {
   getAllCredits,
   creditsToCsv,
@@ -9,7 +9,11 @@ import {
 } from "../../utils/credits.ts";
 import { CollapsibleSection } from "../CollapsibleSection.ts";
 import { downloadFile, downloadAsPNG } from "../../canvas/download.ts";
-import { importStateFromJSON, exportStateAsJSON } from "../../state/json.ts";
+import {
+  importStateFromJSON,
+  exportStateAsJSON,
+  serializeLayersForJson,
+} from "../../state/json.ts";
 import {
   exportSplitAnimations,
   exportSplitItemSheets,
@@ -29,7 +33,10 @@ export const Download: m.Component = {
     const exportToClipboard = async (): Promise<void> => {
       if (!window.canvasRenderer) return;
       try {
-        const json = exportStateAsJSON(state, layers);
+        const json = exportStateAsJSON(
+          state,
+          serializeLayersForJson(drawCalls),
+        );
         debugLog(json);
         await navigator.clipboard.writeText(json);
         alert("Exported to clipboard!");

--- a/sources/state/catalog.ts
+++ b/sources/state/catalog.ts
@@ -39,6 +39,17 @@ export type LoadError =
   | { kind: "loading"; chunk: ChunkName }
   | { kind: "not-found"; id: string };
 
+/** Human-readable description of a catalog `LoadError`. Shared formatter for
+ *  every getter that returns `Result<T, LoadError>`. Exhaustive over `kind`. */
+export function formatLoadError(e: LoadError): string {
+  switch (e.kind) {
+    case "loading":
+      return `chunk "${e.chunk}" not loaded`;
+    case "not-found":
+      return `item ${e.id} not in catalog`;
+  }
+}
+
 // ────────────────────────────────────────────────────────────────────────────
 // Catalog data shapes (audited from real consumer usage)
 // ────────────────────────────────────────────────────────────────────────────

--- a/sources/state/json.ts
+++ b/sources/state/json.ts
@@ -6,6 +6,70 @@ import {
 import { getAllCredits } from "../utils/credits.ts";
 import { state } from "./state.ts";
 import type { Selections, State } from "./state.ts";
+import type { DrawCall } from "../canvas/renderer.ts";
+
+/** Shape of a layer as it appears in the exported `character.json` manifest.
+ *  The live `HTMLImageElement` carried by `DrawCall.source` for custom uploads
+ *  is dropped, and the catalog `spritePath` is rewritten as a path relative to
+ *  the asset root (no `spritesheets/` URL prefix). */
+type SerializedLayerSource =
+  | { kind: "catalog"; spritePath: string }
+  | { kind: "custom" };
+
+export type SerializedLayer = {
+  itemId: string;
+  name?: string;
+  variant: string | null;
+  recolors?: DrawCall["recolors"];
+  zPos: number;
+  layerNum: number;
+  yPos: number;
+  needsRecolor?: boolean;
+  source: SerializedLayerSource;
+  supportedAnimations: string[];
+};
+
+/**
+ * Build the per-layer JSON manifest from the renderer's flat draw-call list.
+ * Deduplicates by `(itemId, layerNum)` — each unique layer appears once with
+ * its `supportedAnimations` aggregated from the draw calls that referenced it.
+ */
+export function serializeLayersForJson(
+  draws: readonly DrawCall[],
+): SerializedLayer[] {
+  const out: SerializedLayer[] = [];
+  for (const draw of draws) {
+    const existing = out.find(
+      (l) => l.itemId === draw.itemId && l.layerNum === draw.layerNum,
+    );
+    if (existing) {
+      existing.supportedAnimations.push(draw.animation);
+      continue;
+    }
+    const source: SerializedLayerSource =
+      draw.source.kind === "catalog"
+        ? {
+            kind: "catalog",
+            spritePath: draw.source.spritePath.substring(
+              "spritesheets/".length,
+            ),
+          }
+        : { kind: "custom" };
+    out.push({
+      itemId: draw.itemId,
+      name: draw.name,
+      variant: draw.variant,
+      recolors: draw.recolors,
+      zPos: draw.zPos,
+      layerNum: draw.layerNum,
+      yPos: draw.yPos,
+      needsRecolor: draw.needsRecolor,
+      source,
+      supportedAnimations: [draw.animation],
+    });
+  }
+  return out;
+}
 
 type CreditsByFile = ReturnType<typeof getAllCredits>;
 

--- a/sources/state/zip.ts
+++ b/sources/state/zip.ts
@@ -11,7 +11,7 @@ import {
   renderSingleItemAnimation,
   SHEET_HEIGHT,
   canvas,
-  layers,
+  drawCalls,
   customAreaItems,
   addedCustomAnimations,
 } from "../canvas/renderer.ts";
@@ -175,7 +175,7 @@ export const exportSplitAnimations = async (
     }
 
     await profiler.phase("staticFiles", async () => {
-      addCharacterJsonAndCredits(zip, creditsFolder, state!, layers);
+      addCharacterJsonAndCredits(zip, creditsFolder, state!, drawCalls);
     });
 
     const metadata = {
@@ -295,7 +295,7 @@ export const exportSplitItemSheets = async (
     }
 
     await profiler.phase("staticFiles", async () => {
-      addCharacterJsonAndCredits(zip, creditsFolder, state!, layers);
+      addCharacterJsonAndCredits(zip, creditsFolder, state!, drawCalls);
     });
 
     const zipBlob = await zipGenerateBlobWithProfiler(profiler, zip);
@@ -551,7 +551,7 @@ export const exportSplitItemAnimations = async (
     }
 
     await profiler.phase("staticFiles", async () => {
-      addCharacterJsonAndCredits(zip, creditsFolder, state!, layers);
+      addCharacterJsonAndCredits(zip, creditsFolder, state!, drawCalls);
     });
 
     const metadata = {
@@ -857,7 +857,7 @@ export const exportIndividualFrames = async (
     );
 
     await profiler.phase("staticFiles", async () => {
-      addCharacterJsonAndCredits(zip, creditsFolder, state!, layers);
+      addCharacterJsonAndCredits(zip, creditsFolder, state!, drawCalls);
     });
 
     const metadata = {

--- a/sources/utils/zip-helpers.ts
+++ b/sources/utils/zip-helpers.ts
@@ -17,9 +17,10 @@ import {
 } from "../canvas/canvas-utils.ts";
 import { debugLog, debugWarn } from "../utils/debug.ts";
 import { getAllCredits, creditsToTxt, creditsToCsv } from "./credits.ts";
-import { exportStateAsJSON } from "../state/json.ts";
+import { exportStateAsJSON, serializeLayersForJson } from "../state/json.ts";
 import type { ZipExportProfiler } from "../performance-profiler.ts";
 import type { State } from "../state/state.ts";
+import type { DrawCall } from "../canvas/renderer.ts";
 
 /**
  * Subset of the JSZip folder API consumed by these helpers and downstream
@@ -582,9 +583,12 @@ export function addCharacterJsonAndCredits(
   zip: ZipFolder,
   creditsFolder: ZipFolder,
   state: State,
-  layers: unknown[],
+  drawCalls: readonly DrawCall[],
 ): void {
-  zip.file("character.json", exportStateAsJSON(state, layers));
+  zip.file(
+    "character.json",
+    exportStateAsJSON(state, serializeLayersForJson(drawCalls)),
+  );
   const allCredits = getAllCredits(state.selections, state.bodyType);
   creditsFolder.file("credits.txt", creditsToTxt(allCredits));
   creditsFolder.file("credits.csv", creditsToCsv(allCredits));

--- a/tests/canvas/renderer-issue-364_spec.js
+++ b/tests/canvas/renderer-issue-364_spec.js
@@ -5,7 +5,7 @@
  *
  * Real sprite URLs (no global Image stub): avoids cache/global issues in the
  * shared `load-image` module. `try`/`finally` plus `resetRendererModuleState()`
- * (layers, itemsToDraw, customAreaItems, addedCustomAnimations, initCanvas) plus
+ * (drawCalls, customAreaItems, addedCustomAnimations, initCanvas) plus
  * `resetImageLoadCache()` and restoring the app catalog keep later specs
  * safe when this file is imported first (e.g. if test order is randomized later).
  */
@@ -17,8 +17,7 @@ import {
   renderCharacter,
   resetRenderCharacterQueueForTests,
   addedCustomAnimations,
-  layers as rendererLayers,
-  itemsToDraw,
+  drawCalls,
   customAreaItems,
 } from "../../sources/canvas/renderer.ts";
 import { resetImageLoadCache } from "../../sources/canvas/load-image.ts";
@@ -70,8 +69,7 @@ describe("canvas/renderer.ts issue #364 (addedCustomAnimations export)", () => {
 
   function resetRendererModuleState() {
     resetRenderCharacterQueueForTests();
-    rendererLayers.length = 0;
-    itemsToDraw.length = 0;
+    drawCalls.length = 0;
     for (const k of Object.keys(customAreaItems)) {
       delete customAreaItems[k];
     }

--- a/tests/fixtures/issue-382/issue382-golden-runner.js
+++ b/tests/fixtures/issue-382/issue382-golden-runner.js
@@ -11,7 +11,7 @@
 import {
   initCanvas,
   canvas as rendererCanvas,
-  layers,
+  drawCalls,
   SHEET_HEIGHT,
   SHEET_WIDTH,
   renderCharacter,
@@ -34,7 +34,7 @@ let fakeZip;
 
 async function runGoldens() {
   resetState();
-  layers.length = 0;
+  drawCalls.length = 0;
 
   await seedBrowserCatalogMergedOnDist(issue382ItemMetadata);
 

--- a/tests/state/zip-issue-382_spec.js
+++ b/tests/state/zip-issue-382_spec.js
@@ -18,7 +18,7 @@ import { describe, it, beforeEach, afterEach } from "mocha-globals";
 import {
   initCanvas,
   canvas as rendererCanvas,
-  layers,
+  drawCalls,
   SHEET_HEIGHT,
   SHEET_WIDTH,
   renderCharacter,
@@ -55,7 +55,7 @@ describe("state/zip.ts issue #382 regression (longsword + full outfit)", () => {
 
   beforeEach(async () => {
     resetState();
-    layers.length = 0;
+    drawCalls.length = 0;
 
     await seedBrowserCatalogMergedOnDist(issue382ItemMetadata);
 

--- a/tests/state/zip_spec.js
+++ b/tests/state/zip_spec.js
@@ -5,7 +5,7 @@ import { describe, it, beforeEach, afterEach } from "mocha-globals";
 import {
   initCanvas,
   canvas as rendererCanvas,
-  layers,
+  drawCalls,
   SHEET_WIDTH,
   SHEET_HEIGHT,
   renderCharacter,
@@ -119,7 +119,7 @@ describe("state/zip.ts", () => {
 
     beforeEach(() => {
       resetState();
-      layers.length = 0;
+      drawCalls.length = 0;
 
       sandbox = sinon.createSandbox();
       window.canvasRenderer = {};
@@ -274,7 +274,7 @@ describe("state/zip.ts", () => {
 
     beforeEach(async () => {
       resetState();
-      layers.length = 0;
+      drawCalls.length = 0;
 
       await seedBrowserCatalogMergedOnDist(ZIP_SPEC_ITEM_METADATA);
 
@@ -655,7 +655,7 @@ describe("state/zip.ts", () => {
 
     beforeEach(async () => {
       resetState();
-      layers.length = 0;
+      drawCalls.length = 0;
 
       await seedBrowserCatalogMergedOnDist(ZIP_SPEC_ITEM_METADATA);
 
@@ -1135,7 +1135,7 @@ describe("state/zip.ts", () => {
 
     beforeEach(() => {
       resetState();
-      layers.length = 0;
+      drawCalls.length = 0;
 
       sandbox = sinon.createSandbox();
       window.canvasRenderer = {};


### PR DESCRIPTION
## Summary

  Two related cleanups on top of the recently-completed TS migration:

  1. **Latent `loadImage(null)` bug.** `runRenderCharacter` was using `getSpritePath(...).unwrapOr(null)` and pushing items with `spritePath: null` on err. Downstream the loader branches on `item.customImage` first and otherwise calls
  `loadImage(item.spritePath!)`. The bang assertion was safe only when the *only* producer of `spritePath: null` was the user-upload branch — but `unwrapOr(null)` introduced a second producer. When `getSpritePath` actually erred
  (`{kind:"missing-layer"}`, `{kind:"missing-bodytype-path"}`, `LoadError`), the err leaked into `loadImage(null)` and surfaced as a generic `Failed to load sprite: null` warn that lost all diagnostic information. Fix: branch on the Result, skip
   the push on err with a specific PathError-shaped warn.

  2. **Conflated renderer / JSON contracts.** `ItemToDraw` had `spritePath: string | null` plus `customImage?: HTMLImageElement` — a discriminated state encoded across two fields with a non-local runtime invariant. `RenderedLayer` (the only
  other type in the chain) was shaped around `JSON.stringify`'s quirks: `Omit<>` based on `ItemToDraw`, with the `HTMLImageElement` left to serialize as `{}` and `fileName: ""` doing double duty as identity + custom-discriminant. Refactor:
  introduce `LayerSource = { kind: "catalog"; spritePath } | { kind: "custom"; image }` as the discriminated union, rename `ItemToDraw` → `DrawCall` (1:1 with `drawImage` calls), drop `RenderedLayer` entirely. Renderer's only export is now
  `drawCalls: DrawCall[]` — the flat draw plan. JSON-specific work (dedup by `(itemId, layerNum)`, `supportedAnimations` aggregation, dropping the `HTMLImageElement`, stripping the `spritesheets/` URL prefix) moves to a new
  `serializeLayersForJson(...)` in `state/json.ts`, called by the two production export paths.

  Also dropped the unused `isCustom: boolean` field on `ItemToDraw` / `DrawCall` — only ever written as `false`, never read.

  ## Changes

  - `sources/canvas/renderer.ts` — `DrawCall` + `LayerSource` types; `drawCalls` export replaces the previous `layers` + `itemsToDraw` pair; `formatPathError` helper; loader uses tagged narrowing on `source.kind`.
  - `sources/state/catalog.ts` — `formatLoadError` extracted next to `LoadError`; reusable by the 12 other getters that return `Result<T, LoadError>`.
  - `sources/state/json.ts` — new `SerializedLayer` type and `serializeLayersForJson` function. `exportStateAsJSON` keeps its opaque `readonly unknown[]` pass-through signature so the existing test (and any ad-hoc callers) is unaffected.
  - `sources/utils/zip-helpers.ts` — `addCharacterJsonAndCredits` now takes `readonly DrawCall[]` and serializes internally.
  - `sources/components/download/Download.ts`, `sources/state/zip.ts` — import `drawCalls` and pass to the typed helpers.
  - Test fixtures + specs updated for the renames.

  ## Wire format change

  `character.json`'s per-layer shape changed. Catalog entry:

  ```diff
   {
     "itemId": "body",
     "variant": "light",
     "zPos": 10,
     "layerNum": 1,
     "yPos": 0,
  -  "isCustom": false,
  -  "fileName": "body/bodies/male/walk/light.png",
  +  "source": { "kind": "catalog", "spritePath": "body/bodies/male/walk/light.png" },
     "supportedAnimations": ["walk", "slash", ...]
   }
  ```

  Custom-upload entry:

  ```diff
   {
     "itemId": "custom-upload",
     "variant": null,
     "zPos": 87,
     "layerNum": 0,
     "yPos": 0,
  -  "isCustom": false,
  -  "customImage": {},
  -  "fileName": "",
  +  "source": { "kind": "custom" },
     "supportedAnimations": ["walk", "slash", ...]
   }
  ```

  `spritePath` content is identical, just relocated under `source`. `importStateFromJSON` doesn't read the `layers` field at all, and no in-repo code consumes the old fields. External tools parsing `character.json` for `fileName` / `isCustom`
  would see them disappear.