### PR TITLE
Refactor catalog

### DIFF
--- a/sources/components/App.ts
+++ b/sources/components/App.ts
@@ -2,11 +2,21 @@
 import m from "mithril";
 import { state } from "../state/state.ts";
 import { syncSelectionsToHash } from "../state/hash.ts";
+import type { CatalogReader } from "../state/catalog.ts";
 import { Download } from "./download/Download.ts";
 import { FiltersPanel } from "./FiltersPanel.ts";
 import { Credits } from "./download/Credits.ts";
 import { AdvancedTools } from "./advanced/AdvancedTools.ts";
 import { renderCharacter } from "../canvas/renderer.ts";
+
+/**
+ * App is the composition root for catalog DI. main.ts mounts it with the
+ * `defaultCatalog` instance; App threads narrow slices down to children that
+ * have migrated to receive `catalog` via attrs (so far: FiltersPanel and its
+ * subtree). Children that still import from `state/catalog.ts` directly are
+ * unaffected — they read the same `defaultCatalog` state under the hood.
+ */
+type AppAttrs = { catalog: CatalogReader };
 
 type AppState = {
   prevSelections: string;
@@ -15,7 +25,7 @@ type AppState = {
   prevCustomZPos: number;
 };
 
-export const App: m.Component<Record<string, never>, AppState> = {
+export const App: m.Component<AppAttrs, AppState> = {
   oninit(vnode) {
     // Track previous state to detect changes
     vnode.state.prevSelections = JSON.stringify(state.selections);
@@ -52,10 +62,10 @@ export const App: m.Component<Record<string, never>, AppState> = {
       vnode.state.prevCustomZPos = currentCustomZPos;
     }
   },
-  view() {
+  view(vnode) {
     return m("div", [
       m(Download),
-      m(FiltersPanel),
+      m(FiltersPanel, { catalog: vnode.attrs.catalog }),
       m(Credits),
       m(AdvancedTools),
     ]);

--- a/sources/components/App.ts
+++ b/sources/components/App.ts
@@ -64,7 +64,7 @@ export const App: m.Component<AppAttrs, AppState> = {
   },
   view(vnode) {
     return m("div", [
-      m(Download),
+      m(Download, { catalog: vnode.attrs.catalog }),
       m(FiltersPanel, { catalog: vnode.attrs.catalog }),
       m(Credits),
       m(AdvancedTools),

--- a/sources/components/FiltersPanel.ts
+++ b/sources/components/FiltersPanel.ts
@@ -38,7 +38,7 @@ export const FiltersPanel: m.Component<FiltersPanelAttrs> = {
           ),
         ]),
         m("div.mb-4", m(CurrentSelections, { catalog: vnode.attrs.catalog })),
-        m(CategoryTree),
+        m(CategoryTree, { catalog: vnode.attrs.catalog }),
       ],
     );
   },

--- a/sources/components/FiltersPanel.ts
+++ b/sources/components/FiltersPanel.ts
@@ -1,5 +1,6 @@
 // Filters Panel - combines Controls, LicenseFilters, AnimationFilters, CurrentSelections, and CategoryTree
 import m from "mithril";
+import type { CatalogReader } from "../state/catalog.ts";
 import { SearchControl } from "./filters/SearchControl.ts";
 import { LicenseFilters } from "./filters/LicenseFilters.ts";
 import { AnimationFilters } from "./filters/AnimationFilters.ts";
@@ -7,8 +8,10 @@ import { CurrentSelections } from "./selections/CurrentSelections.ts";
 import { CategoryTree } from "./tree/CategoryTree.ts";
 import { CollapsibleSection } from "./CollapsibleSection.ts";
 
-export const FiltersPanel: m.Component = {
-  view() {
+type FiltersPanelAttrs = { catalog: CatalogReader };
+
+export const FiltersPanel: m.Component<FiltersPanelAttrs> = {
+  view(vnode) {
     return m(
       CollapsibleSection,
       {
@@ -16,7 +19,7 @@ export const FiltersPanel: m.Component = {
         defaultOpen: true,
       },
       [
-        m("div.mb-4", m(SearchControl)),
+        m("div.mb-4", m(SearchControl, { catalog: vnode.attrs.catalog })),
         // Responsive wrapper for License and Animation filters
         m("div.columns.is-multiline.m-0", [
           m(

--- a/sources/components/FiltersPanel.ts
+++ b/sources/components/FiltersPanel.ts
@@ -27,17 +27,17 @@ export const FiltersPanel: m.Component<FiltersPanelAttrs> = {
             {
               class: "filters-column",
             },
-            m(LicenseFilters),
+            m(LicenseFilters, { catalog: vnode.attrs.catalog }),
           ),
           m(
             "div.column.is-half-desktop.is-12-mobile",
             {
               class: "filters-column",
             },
-            m(AnimationFilters),
+            m(AnimationFilters, { catalog: vnode.attrs.catalog }),
           ),
         ]),
-        m("div.mb-4", m(CurrentSelections)),
+        m("div.mb-4", m(CurrentSelections, { catalog: vnode.attrs.catalog })),
         m(CategoryTree),
       ],
     );

--- a/sources/components/download/Download.ts
+++ b/sources/components/download/Download.ts
@@ -21,14 +21,17 @@ import {
   exportIndividualFrames,
 } from "../../state/zip.ts";
 import { debugLog } from "../../utils/debug.ts";
-import { isLayersReady } from "../../state/catalog.ts";
+import type { CatalogReader } from "../../state/catalog.ts";
 
-const zipExportDisabled = () => !isLayersReady();
 const zipExportTitle = "Wait for layer data to finish loading";
 
-export const Download: m.Component = {
-  view() {
-    const zipDisabled = zipExportDisabled();
+type DownloadAttrs = {
+  catalog: Pick<CatalogReader, "isLayersReady">;
+};
+
+export const Download: m.Component<DownloadAttrs> = {
+  view(vnode) {
+    const zipDisabled = !vnode.attrs.catalog.isLayersReady();
 
     const exportToClipboard = async (): Promise<void> => {
       if (!window.canvasRenderer) return;

--- a/sources/components/filters/AnimationFilters.ts
+++ b/sources/components/filters/AnimationFilters.ts
@@ -1,6 +1,6 @@
 // Animation Filters component
 import m from "mithril";
-import { isLiteReady } from "../../state/catalog.ts";
+import type { CatalogReader } from "../../state/catalog.ts";
 import { state } from "../../state/state.ts";
 import { isItemAnimationCompatible } from "../../state/filters.ts";
 import { ANIMATIONS } from "../../state/constants.ts";
@@ -34,16 +34,19 @@ export function getAnimations(): readonly AnimationOption[] {
 }
 
 type AnimationFiltersState = { isExpanded: boolean };
+type AnimationFiltersAttrs = {
+  catalog: Pick<CatalogReader, "isLiteReady">;
+};
 
 export const AnimationFilters: m.Component<
-  Record<string, never>,
+  AnimationFiltersAttrs,
   AnimationFiltersState
 > = {
   oninit(vnode) {
     vnode.state.isExpanded = false;
   },
   view(vnode) {
-    const liteReady = isLiteReady();
+    const liteReady = vnode.attrs.catalog.isLiteReady();
 
     const removeIncompatibleItems = () => {
       const toRemove: string[] = [];

--- a/sources/components/filters/LicenseFilters.ts
+++ b/sources/components/filters/LicenseFilters.ts
@@ -1,7 +1,7 @@
 // License Filters component
 import m from "mithril";
 import { state } from "../../state/state.ts";
-import { isCreditsReady, isLiteReady } from "../../state/catalog.ts";
+import type { CatalogReader } from "../../state/catalog.ts";
 import { isItemLicenseCompatible } from "../../state/filters.ts";
 import { LICENSE_CONFIG } from "../../state/constants.ts";
 
@@ -39,16 +39,19 @@ export function getLicenseConfig(): readonly LicenseOption[] {
 }
 
 type LicenseFiltersState = { isExpanded: boolean };
+type LicenseFiltersAttrs = {
+  catalog: Pick<CatalogReader, "isLiteReady" | "isCreditsReady">;
+};
 
 export const LicenseFilters: m.Component<
-  Record<string, never>,
+  LicenseFiltersAttrs,
   LicenseFiltersState
 > = {
   oninit(vnode) {
     vnode.state.isExpanded = false;
   },
   view(vnode) {
-    const liteReady = isLiteReady();
+    const liteReady = vnode.attrs.catalog.isLiteReady();
 
     const removeIncompatibleItems = () => {
       const toRemove: string[] = [];
@@ -68,7 +71,7 @@ export const LicenseFilters: m.Component<
       }
     };
 
-    const creditsReady = isCreditsReady();
+    const creditsReady = vnode.attrs.catalog.isCreditsReady();
 
     const incompatibleSelections = creditsReady
       ? Object.values(state.selections).filter(

--- a/sources/components/filters/SearchControl.ts
+++ b/sources/components/filters/SearchControl.ts
@@ -1,11 +1,15 @@
 // Search control component
 import m from "mithril";
-import { isLiteReady } from "../../state/catalog.ts";
+import type { CatalogReader } from "../../state/catalog.ts";
 import { state } from "../../state/state.ts";
 
-export const SearchControl: m.Component = {
-  view() {
-    const liteReady = isLiteReady();
+type SearchControlAttrs = {
+  catalog: Pick<CatalogReader, "isLiteReady">;
+};
+
+export const SearchControl: m.Component<SearchControlAttrs> = {
+  view(vnode) {
+    const liteReady = vnode.attrs.catalog.isLiteReady();
     return m("div.field", [
       m("label.label", "Search:"),
       m("input.input[type=search][placeholder=Search]", {

--- a/sources/components/selections/CurrentSelections.ts
+++ b/sources/components/selections/CurrentSelections.ts
@@ -1,19 +1,23 @@
 // Current selections component
 import m from "mithril";
-import {
-  getItemMerged,
-  isCreditsReady,
-  isLiteReady,
-} from "../../state/catalog.ts";
+import type { CatalogReader } from "../../state/catalog.ts";
 import { state } from "../../state/state.ts";
 import {
   isItemLicenseCompatible,
   isItemAnimationCompatible,
 } from "../../state/filters.ts";
 
-export const CurrentSelections: m.Component = {
-  view() {
-    if (!isLiteReady()) {
+type CurrentSelectionsAttrs = {
+  catalog: Pick<
+    CatalogReader,
+    "isLiteReady" | "isCreditsReady" | "getItemMerged"
+  >;
+};
+
+export const CurrentSelections: m.Component<CurrentSelectionsAttrs> = {
+  view(vnode) {
+    const { catalog } = vnode.attrs;
+    if (!catalog.isLiteReady()) {
       return m("div", [
         m("h3.title.is-5", "Current Selections"),
         m("p.is-size-7.has-text-grey", "Loading item list…"),
@@ -29,7 +33,7 @@ export const CurrentSelections: m.Component = {
       ]);
     }
 
-    const creditsReady = isCreditsReady();
+    const creditsReady = catalog.isCreditsReady();
 
     return m("div", [
       m("h3.title.is-5", "Current Selections"),
@@ -39,7 +43,7 @@ export const CurrentSelections: m.Component = {
           const isLicenseCompatible = isItemLicenseCompatible(selection.itemId);
           const isAnimCompatible = isItemAnimationCompatible(selection.itemId);
           const isCompatible = isLicenseCompatible && isAnimCompatible;
-          const metaResult = getItemMerged(selection.itemId);
+          const metaResult = catalog.getItemMerged(selection.itemId);
           const meta = metaResult.isOk() ? metaResult.value : null;
 
           const allLicenses = new Set<string>();

--- a/sources/components/tree/CategoryTree.ts
+++ b/sources/components/tree/CategoryTree.ts
@@ -6,12 +6,19 @@ import {
   getSelectionGroup,
   applyMatchBodyColor,
 } from "../../state/state.ts";
-import { isLiteReady } from "../../state/catalog.ts";
-import { getCategoryTree, getItemMerged } from "../../state/catalog.ts";
-import type { CategoryTree as CategoryTreeShape } from "../../state/catalog.ts";
+import type {
+  CatalogReader,
+  CategoryTree as CategoryTreeShape,
+} from "../../state/catalog.ts";
 import { renderResult } from "../../utils/render-result.ts";
 import { BodyTypeSelector } from "./BodyTypeSelector.ts";
 import { TreeNode } from "./TreeNode.ts";
+
+// Forwarder: passes catalog down to TreeNode subtree. Declared as the full
+// reader (rather than a narrow Pick) because the transitive union of what its
+// descendants need covers most of CatalogReader anyway, and enumerating it
+// would make adding a downstream method an N-place edit. Leaves narrow.
+type CategoryTreeAttrs = { catalog: CatalogReader };
 
 function renderLoadingHost() {
   return m("div.box.has-background-light.category-tree-panel", [
@@ -27,8 +34,8 @@ function renderLoadingHost() {
   ]);
 }
 
-function renderTree(categoryTree: CategoryTreeShape) {
-  const liteReady = isLiteReady();
+function renderTree(categoryTree: CategoryTreeShape, catalog: CatalogReader) {
+  const liteReady = catalog.isLiteReady();
 
   return m("div.box.has-background-light.category-tree-panel", [
     m(
@@ -59,7 +66,7 @@ function renderTree(categoryTree: CategoryTreeShape) {
                 if (!liteReady) return;
                 for (const [, selection] of Object.entries(state.selections)) {
                   const { itemId } = selection;
-                  getItemMerged(itemId).match(
+                  catalog.getItemMerged(itemId).match(
                     (meta) => {
                       let pathSoFar = "";
                       // Expand all path segments (categories)
@@ -145,17 +152,19 @@ function renderTree(categoryTree: CategoryTreeShape) {
             key: categoryName,
             name: categoryName,
             node: categoryNode,
+            catalog,
           }),
       ),
     ]),
   ]);
 }
 
-export const CategoryTree: m.Component = {
-  view() {
+export const CategoryTree: m.Component<CategoryTreeAttrs> = {
+  view(vnode) {
+    const { catalog } = vnode.attrs;
     return renderResult(
-      getCategoryTree(),
-      (categoryTree) => renderTree(categoryTree),
+      catalog.getCategoryTree(),
+      (categoryTree) => renderTree(categoryTree, catalog),
       () => renderLoadingHost(),
     );
   },

--- a/sources/components/tree/ItemWithRecolors.ts
+++ b/sources/components/tree/ItemWithRecolors.ts
@@ -2,13 +2,14 @@
 import m from "mithril";
 import classNames from "classnames";
 import { state, getSelectionGroup, selectItem } from "../../state/state.ts";
-import { isPaletteReady } from "../../state/catalog.ts";
+import type { CatalogReader, ItemMerged } from "../../state/catalog.ts";
 import { drawRecolorPreview } from "../../canvas/palette-recolor.ts";
 import { getPaletteOptions } from "../../state/palettes.ts";
 import { PaletteSelectModal } from "./PaletteSelectModal.ts";
 import { COMPACT_FRAME_SIZE, FRAME_SIZE } from "../../state/constants.ts";
-import type { ItemMerged } from "../../state/catalog.ts";
 
+// Forwarder: own use is just `isPaletteReady`, but it forwards a wider slice
+// to PaletteSelectModal. Full reader keeps the contract simple; leaf narrows.
 export type ItemWithRecolorsAttrs = {
   itemId: string;
   meta: ItemMerged;
@@ -16,6 +17,7 @@ export type ItemWithRecolorsAttrs = {
   isCompatible: boolean;
   tooltipText: string;
   showItemTooltips?: boolean;
+  catalog: CatalogReader;
 };
 
 type ItemWithRecolorsState = {
@@ -42,6 +44,7 @@ export const ItemWithRecolors: m.Component<
       isCompatible,
       tooltipText,
       showItemTooltips = true,
+      catalog,
     } = vnode.attrs;
     const rowTitle = showItemTooltips ? tooltipText : undefined;
     const compactDisplay = state.compactDisplay;
@@ -58,7 +61,7 @@ export const ItemWithRecolors: m.Component<
     const selection = state.selections[selectionGroup];
     const isSelected = selection?.itemId === itemId;
 
-    const paletteReady = isPaletteReady();
+    const paletteReady = catalog.isPaletteReady();
 
     // Build palette/color options for all recolor fields
     const [paletteOptions, selectedColors] = getPaletteOptions(itemId, meta);
@@ -77,6 +80,7 @@ export const ItemWithRecolors: m.Component<
         selectedColors,
         compactDisplay,
         rootViewNode,
+        catalog,
         onClose: () => {
           rootViewNode.state.showPaletteModal = null;
           rootViewNode.state._palettePreviewLastTotal = undefined;

--- a/sources/components/tree/PaletteSelectModal.ts
+++ b/sources/components/tree/PaletteSelectModal.ts
@@ -2,18 +2,22 @@ import m from "mithril";
 import classNames from "classnames";
 import { Result } from "neverthrow";
 import { drawRecolorPreview } from "../../canvas/palette-recolor.ts";
-import {
-  chunkReady,
-  getItemMerged,
-  getPaletteMetadata,
+import type {
+  CatalogReader,
+  ItemMerged,
+  PaletteMetadata,
+  LoadError,
 } from "../../state/catalog.ts";
-import type { ItemMerged, PaletteMetadata } from "../../state/catalog.ts";
 import { renderResult } from "../../utils/render-result.ts";
-import type { LoadError } from "../../state/catalog.ts";
 import { state, getSelectionGroup } from "../../state/state.ts";
 import { ucwords } from "../../utils/helpers.ts";
 import { COMPACT_FRAME_SIZE, FRAME_SIZE } from "../../state/constants.ts";
 import type { PaletteOption } from "../../state/palettes.ts";
+
+type PaletteSelectModalCatalog = Pick<
+  CatalogReader,
+  "chunkReady" | "getItemMerged" | "getPaletteMetadata"
+>;
 
 type RootViewState = {
   palettePreviewGateSeq?: number;
@@ -37,6 +41,7 @@ export type PaletteSelectModalAttrs = {
   rootViewNode: RootViewRef;
   onClose: () => void;
   onSelect: (recolor: string) => void;
+  catalog: PaletteSelectModalCatalog;
 };
 
 /**
@@ -298,17 +303,17 @@ function renderModal(
 
 export const PaletteSelectModal: m.Component<PaletteSelectModalAttrs> = {
   view(vnode) {
-    const { itemId, onClose } = vnode.attrs;
+    const { itemId, onClose, catalog } = vnode.attrs;
     // Order matters: Result.combine short-circuits to the first Err. We
     // surface a different loading message depending on which chunk is
     // missing (matches the legacy two-stage UX: palette first, then layer).
     return renderResult(
       Result.combine([
-        chunkReady("palette"),
-        chunkReady("lite"),
-        chunkReady("layers"),
-        getPaletteMetadata(),
-        getItemMerged(itemId),
+        catalog.chunkReady("palette"),
+        catalog.chunkReady("lite"),
+        catalog.chunkReady("layers"),
+        catalog.getPaletteMetadata(),
+        catalog.getItemMerged(itemId),
       ]),
       ([, , , paletteMeta, meta]) =>
         renderModal(vnode.attrs, paletteMeta, meta),

--- a/sources/components/tree/TreeNode.ts
+++ b/sources/components/tree/TreeNode.ts
@@ -1,14 +1,11 @@
 // Recursive tree node component
 import m from "mithril";
 import { state, getSelectionGroup } from "../../state/state.ts";
-import { isCreditsReady, isLiteReady } from "../../state/catalog.ts";
-import {
-  chunkReady,
-  getItemCredits,
-  getItemLite,
-  getItemMerged,
+import type {
+  CatalogReader,
+  CategoryTreeNode,
+  ItemMerged,
 } from "../../state/catalog.ts";
-import type { CategoryTreeNode, ItemMerged } from "../../state/catalog.ts";
 import { renderResult } from "../../utils/render-result.ts";
 import {
   isItemLicenseCompatible,
@@ -23,6 +20,9 @@ import {
 import { ItemWithVariants } from "./ItemWithVariants.ts";
 import { ItemWithRecolors } from "./ItemWithRecolors.ts";
 
+// Forwarder: catalog flows to ItemWithRecolors → PaletteSelectModal. Full
+// reader avoids enumerating the transitive union of downstream needs. The
+// leaf (PaletteSelectModal) narrows.
 export type TreeNodeAttrs = {
   name: string;
   node: CategoryTreeNode & {
@@ -31,11 +31,13 @@ export type TreeNodeAttrs = {
     label?: string;
   };
   pathPrefix?: string;
+  catalog: CatalogReader;
 };
 
 type ItemListCtx = {
   isNodeAnimCompatible: boolean;
   searchQuery: string;
+  catalog: CatalogReader;
 };
 
 function renderSkeletons(itemIds: string[]) {
@@ -52,7 +54,7 @@ function renderSkeletons(itemIds: string[]) {
 }
 
 function renderItem(itemId: string, meta: ItemMerged, ctx: ItemListCtx) {
-  const { isNodeAnimCompatible, searchQuery } = ctx;
+  const { isNodeAnimCompatible, searchQuery, catalog } = ctx;
   const displayName = meta.name;
   const hasVariants = meta.variants && meta.variants.length > 0;
   const hasRecolors = !hasVariants && meta.recolors && meta.recolors.length > 0;
@@ -68,11 +70,11 @@ function renderItem(itemId: string, meta: ItemMerged, ctx: ItemListCtx) {
 
   // Build tooltip text (license list needs credits chunk)
   let licensesText: string;
-  if (!isCreditsReady()) {
+  if (!catalog.isCreditsReady()) {
     licensesText = "License info loading…";
   } else {
     const allLicenses = new Set<string>();
-    const credits = getItemCredits(itemId).unwrapOr([]);
+    const credits = catalog.getItemCredits(itemId).unwrapOr([]);
     for (const credit of credits) {
       for (const lic of credit.licenses) {
         allLicenses.add(lic.trim());
@@ -99,7 +101,7 @@ function renderItem(itemId: string, meta: ItemMerged, ctx: ItemListCtx) {
   }
   tooltipText += `${licensesText}\n${animsText}`;
 
-  const showItemTooltips = isCreditsReady();
+  const showItemTooltips = catalog.isCreditsReady();
 
   if (!hasVariants && !hasRecolors) {
     // Simple item with no variants or recolors
@@ -138,6 +140,7 @@ function renderItem(itemId: string, meta: ItemMerged, ctx: ItemListCtx) {
       isCompatible,
       tooltipText,
       showItemTooltips,
+      catalog,
     });
   }
   return m(ItemWithVariants, {
@@ -152,10 +155,10 @@ function renderItem(itemId: string, meta: ItemMerged, ctx: ItemListCtx) {
 }
 
 function renderItemList(itemIds: string[], ctx: ItemListCtx) {
-  const { isNodeAnimCompatible, searchQuery } = ctx;
+  const { isNodeAnimCompatible, searchQuery, catalog } = ctx;
   return itemIds
     .filter((itemId) => {
-      const liteResult = getItemLite(itemId);
+      const liteResult = catalog.getItemLite(itemId);
       if (liteResult.isErr()) return false; // unknown id (stale URL etc.)
       const lite = liteResult.value;
       // Filter: Only show items compatible with current body type
@@ -173,7 +176,7 @@ function renderItemList(itemIds: string[], ctx: ItemListCtx) {
       return true;
     })
     .map((itemId) => {
-      const mergedResult = getItemMerged(itemId);
+      const mergedResult = catalog.getItemMerged(itemId);
       if (mergedResult.isErr()) return null; // unknown id
       return renderItem(itemId, mergedResult.value, ctx);
     });
@@ -181,7 +184,7 @@ function renderItemList(itemIds: string[], ctx: ItemListCtx) {
 
 export const TreeNode: m.Component<TreeNodeAttrs> = {
   view(vnode) {
-    const { name, node, pathPrefix = "" } = vnode.attrs;
+    const { name, node, pathPrefix = "", catalog } = vnode.attrs;
     const nodePath = pathPrefix ? `${pathPrefix}-${name}` : name;
     const searchQuery = state.searchQuery;
     const hasSearchMatches = nodeHasMatches(node, searchQuery);
@@ -221,10 +224,14 @@ export const TreeNode: m.Component<TreeNodeAttrs> = {
       false;
     const displayName = node.label ?? capitalize(name);
 
-    const categoryTitle = isLiteReady() ? tooltipText : undefined;
+    const categoryTitle = catalog.isLiteReady() ? tooltipText : undefined;
 
     const itemIds = node.items ?? [];
-    const itemListCtx: ItemListCtx = { isNodeAnimCompatible, searchQuery };
+    const itemListCtx: ItemListCtx = {
+      isNodeAnimCompatible,
+      searchQuery,
+      catalog,
+    };
 
     return m(
       "div",
@@ -255,12 +262,13 @@ export const TreeNode: m.Component<TreeNodeAttrs> = {
                 name: childName,
                 node: childNode,
                 pathPrefix: nodePath,
+                catalog,
               }),
             ),
             // Render items in this category. Skeletons until lite registers,
             // then real items via .filter / .map using typed getters.
             renderResult(
-              chunkReady("lite"),
+              catalog.chunkReady("lite"),
               () => renderItemList(itemIds, itemListCtx),
               () => renderSkeletons(itemIds),
             ),

--- a/sources/main.ts
+++ b/sources/main.ts
@@ -4,7 +4,7 @@ import m from "mithril";
 import "./styles/critical-entry.scss";
 import "./vendor-globals.ts";
 import { loadAllMetadata } from "./install-item-metadata.ts";
-import { catalogReady } from "./state/catalog.ts";
+import { catalogReady, defaultCatalog } from "./state/catalog.ts";
 
 // Import debug first so `window.DEBUG` is set before other modules run.
 import { debugLog, getDebugParam } from "./utils/debug.ts";
@@ -126,7 +126,10 @@ let hashHydrationInitDone = false;
 // Wait for DOM to be ready, then mount UI; catalog may already be loading or ready.
 document.addEventListener("DOMContentLoaded", () => {
   // Mount roots are static markup in index.html; assert non-null.
-  m.mount(document.getElementById("mithril-filters")!, App);
+  // App is the composition root for catalog DI — services pass through via attrs.
+  m.mount(document.getElementById("mithril-filters")!, {
+    view: () => m(App, { catalog: defaultCatalog }),
+  });
   m.mount(document.getElementById("mithril-preview")!, AnimationPreview);
   m.mount(
     document.getElementById("mithril-spritesheet-preview")!,

--- a/sources/state/catalog.ts
+++ b/sources/state/catalog.ts
@@ -19,6 +19,14 @@
  *
  * Consumer-side code pairs this with the `renderResult` helper (in the render
  * tree) or with `.match` / `.unwrapOr` / `if (r.isErr())` (everywhere else).
+ *
+ * Catalog DI migration:
+ *   - `createCatalog()` is the factory used by `main.ts` and by tests that
+ *     want an isolated instance.
+ *   - `defaultCatalog` is a module-level instance — the same shared state we
+ *     had before the factory, just encapsulated. Legacy free-function exports
+ *     delegate to it; they're thin wrappers preserved for incremental
+ *     migration and get removed in the final cleanup phase.
  */
 
 import { ok, err, type Result } from "neverthrow";
@@ -169,7 +177,72 @@ export type PaletteMetadata = {
 };
 
 // ────────────────────────────────────────────────────────────────────────────
-// Internal: stage + store state
+// Catalog interface — split into reader + writer halves
+// ────────────────────────────────────────────────────────────────────────────
+
+export type CatalogReady = {
+  readonly onIndexReady: Promise<void>;
+  readonly onLiteReady: Promise<void>;
+  readonly onCreditsReady: Promise<void>;
+  readonly onPaletteReady: Promise<void>;
+  readonly onLayersReady: Promise<void>;
+  readonly onAllReady: Promise<void>;
+};
+
+/** Read-only surface — what components and downstream factories should consume. */
+export type CatalogReader = {
+  chunkReady(chunk: ChunkName): Result<true, LoadError>;
+  getItemLite(id: string): Result<ItemLite, LoadError>;
+  getItemMerged(id: string): Result<ItemMerged, LoadError>;
+  getItemCredits(id: string): Result<Credit[], LoadError>;
+  getItemLayers(id: string): Result<Record<string, LayerEntry>, LoadError>;
+  getPaletteMetadata(): Result<PaletteMetadata, LoadError>;
+  getCategoryTree(): Result<CategoryTree, LoadError>;
+  getMetadataIndexes(): Result<MetadataIndexes, LoadError>;
+  getAliasMetadata(): Result<AliasMetadata, LoadError>;
+  isIndexReady(): boolean;
+  isLiteReady(): boolean;
+  isCreditsReady(): boolean;
+  isPaletteReady(): boolean;
+  isLayersReady(): boolean;
+  buildItemsByTypeNameFromRegisteredLite(): Record<string, SlimByTypeNameRow[]>;
+  readonly ready: CatalogReady;
+};
+
+/** Write-only surface — only the boot path (`install-item-metadata.ts`) and
+ *  test setup should hold this. */
+export type CatalogWriter = {
+  registerFromIndexModule(exports_: {
+    aliasMetadata: AliasMetadata;
+    categoryTree: CategoryTree;
+    metadataIndexes: MetadataIndexes;
+  }): void;
+  registerFromPaletteModule(exports_: {
+    paletteMetadata: PaletteMetadata;
+  }): void;
+  registerFromItemModule(exports_: {
+    itemMetadata: Record<string, ItemLite>;
+  }): void;
+  registerFromCreditsModule(exports_: {
+    itemCredits: Record<string, Credit[]>;
+  }): void;
+  registerFromLayersModule(exports_: {
+    itemLayers: Record<string, Record<string, LayerEntry>>;
+  }): void;
+  loadCatalogFromFixtures(fixtureGlobals: {
+    itemMetadata: Record<string, unknown>;
+    aliasMetadata: AliasMetadata;
+    categoryTree: CategoryTree;
+    metadataIndexes: MetadataIndexes;
+    paletteMetadata: PaletteMetadata;
+  }): void;
+  resetForTests(): void;
+};
+
+export type Catalog = CatalogReader & CatalogWriter;
+
+// ────────────────────────────────────────────────────────────────────────────
+// Internal helpers — pure, outside the factory
 // ────────────────────────────────────────────────────────────────────────────
 
 type Stage = {
@@ -194,71 +267,6 @@ function makeStage(): Stage {
   return stage;
 }
 
-let indexStage = makeStage();
-let liteStage = makeStage();
-let creditsStage = makeStage();
-let paletteStage = makeStage();
-let layersStage = makeStage();
-
-let aliasMetadataStore: AliasMetadata | null = null;
-let categoryTreeStore: CategoryTree | null = null;
-let metadataIndexesStore: MetadataIndexes | null = null;
-let itemLiteStore: Record<string, ItemLite> | null = null;
-let itemCreditsStore: Record<string, Credit[]> | null = null;
-let itemLayersStore: Record<string, Record<string, LayerEntry>> | null = null;
-let paletteMetadataStore: PaletteMetadata | null = null;
-
-// ────────────────────────────────────────────────────────────────────────────
-// Public: catalogReady promises + isXReady predicates
-// ────────────────────────────────────────────────────────────────────────────
-
-/**
- * Promises that settle once when the corresponding chunk registers (idempotent
- * per stage). After `resetCatalogForTests()`, use these getters again for
- * fresh promises.
- */
-export const catalogReady = {
-  get onIndexReady() {
-    return indexStage.promise;
-  },
-  get onLiteReady() {
-    return liteStage.promise;
-  },
-  get onCreditsReady() {
-    return creditsStage.promise;
-  },
-  get onPaletteReady() {
-    return paletteStage.promise;
-  },
-  get onLayersReady() {
-    return layersStage.promise;
-  },
-  get onAllReady() {
-    return Promise.all([
-      indexStage.promise,
-      liteStage.promise,
-      creditsStage.promise,
-      paletteStage.promise,
-      layersStage.promise,
-    ]).then(() => {});
-  },
-};
-
-/**
- * Synchronous readiness predicates (mirrors `catalogReady` but without
- * awaiting). Useful in render paths and event handlers where you need a
- * boolean without subscribing to a promise.
- */
-export const isIndexReady = (): boolean => indexStage.resolved;
-export const isLiteReady = (): boolean => liteStage.resolved;
-export const isCreditsReady = (): boolean => creditsStage.resolved;
-export const isPaletteReady = (): boolean => paletteStage.resolved;
-export const isLayersReady = (): boolean => layersStage.resolved;
-
-// ────────────────────────────────────────────────────────────────────────────
-// Internal helpers
-// ────────────────────────────────────────────────────────────────────────────
-
 function splitFullItemMetadataForCatalog(
   fullItemMetadata: Record<string, unknown>,
 ): {
@@ -282,242 +290,341 @@ function splitFullItemMetadataForCatalog(
   return { itemMetadataLite, itemCredits, itemLayers };
 }
 
-/**
- * Fills `variants` and `recolors[0].variants` from `metadataIndexesStore` when
- * the lite chunk was emitted with interned `v` / `r` (shared tables live only
- * in `index-metadata.js`).
- */
-function expandInternedItemLitesInStore(): void {
-  if (itemLiteStore === null || metadataIndexesStore === null) return;
-  const { variantArrays, recolorVariantArrays } = metadataIndexesStore;
-  if (!Array.isArray(variantArrays) || !Array.isArray(recolorVariantArrays)) {
-    return;
-  }
-  for (const itemId of Object.keys(itemLiteStore)) {
-    const cur = itemLiteStore[itemId];
-    if (isInternedItemLite(cur)) {
-      itemLiteStore[itemId] = expandInternedItemLite(
-        cur,
-        variantArrays,
-        recolorVariantArrays,
-      ) as ItemLite;
+const loading = (chunk: ChunkName): LoadError => ({ kind: "loading", chunk });
+const notFound = (id: string): LoadError => ({ kind: "not-found", id });
+
+// ────────────────────────────────────────────────────────────────────────────
+// Factory
+// ────────────────────────────────────────────────────────────────────────────
+
+export function createCatalog(): Catalog {
+  // All stage trackers and stores live in this closure — unreachable from
+  // outside the factory. Mutation only happens through the registrar methods
+  // returned below.
+  let indexStage = makeStage();
+  let liteStage = makeStage();
+  let creditsStage = makeStage();
+  let paletteStage = makeStage();
+  let layersStage = makeStage();
+
+  let aliasMetadataStore: AliasMetadata | null = null;
+  let categoryTreeStore: CategoryTree | null = null;
+  let metadataIndexesStore: MetadataIndexes | null = null;
+  let itemLiteStore: Record<string, ItemLite> | null = null;
+  let itemCreditsStore: Record<string, Credit[]> | null = null;
+  let itemLayersStore: Record<string, Record<string, LayerEntry>> | null = null;
+  let paletteMetadataStore: PaletteMetadata | null = null;
+
+  /**
+   * Fills `variants` and `recolors[0].variants` from `metadataIndexesStore`
+   * when the lite chunk was emitted with interned `v` / `r` (shared tables
+   * live only in `index-metadata.js`).
+   */
+  function expandInternedItemLitesInStore(): void {
+    if (itemLiteStore === null || metadataIndexesStore === null) return;
+    const { variantArrays, recolorVariantArrays } = metadataIndexesStore;
+    if (!Array.isArray(variantArrays) || !Array.isArray(recolorVariantArrays)) {
+      return;
+    }
+    for (const itemId of Object.keys(itemLiteStore)) {
+      const cur = itemLiteStore[itemId];
+      if (isInternedItemLite(cur)) {
+        itemLiteStore[itemId] = expandInternedItemLite(
+          cur,
+          variantArrays,
+          recolorVariantArrays,
+        ) as ItemLite;
+      }
     }
   }
+
+  const ready: CatalogReady = {
+    get onIndexReady() {
+      return indexStage.promise;
+    },
+    get onLiteReady() {
+      return liteStage.promise;
+    },
+    get onCreditsReady() {
+      return creditsStage.promise;
+    },
+    get onPaletteReady() {
+      return paletteStage.promise;
+    },
+    get onLayersReady() {
+      return layersStage.promise;
+    },
+    get onAllReady() {
+      return Promise.all([
+        indexStage.promise,
+        liteStage.promise,
+        creditsStage.promise,
+        paletteStage.promise,
+        layersStage.promise,
+      ]).then(() => {});
+    },
+  };
+
+  return {
+    ready,
+
+    // readiness predicates
+    isIndexReady: () => indexStage.resolved,
+    isLiteReady: () => liteStage.resolved,
+    isCreditsReady: () => creditsStage.resolved,
+    isPaletteReady: () => paletteStage.resolved,
+    isLayersReady: () => layersStage.resolved,
+
+    chunkReady(chunk) {
+      const stage = (
+        {
+          index: indexStage,
+          lite: liteStage,
+          credits: creditsStage,
+          palette: paletteStage,
+          layers: layersStage,
+        } as const
+      )[chunk];
+      return stage.resolved ? ok(true as const) : err(loading(chunk));
+    },
+
+    // result-returning getters
+    getItemLite(id) {
+      if (!liteStage.resolved) return err(loading("lite"));
+      const item = itemLiteStore?.[id];
+      return item ? ok(item) : err(notFound(id));
+    },
+
+    getItemMerged(id) {
+      if (!liteStage.resolved) return err(loading("lite"));
+      const lite = itemLiteStore?.[id];
+      if (!lite) return err(notFound(id));
+      const layers = layersStage.resolved ? (itemLayersStore?.[id] ?? {}) : {};
+      const credits = creditsStage.resolved
+        ? (itemCreditsStore?.[id] ?? [])
+        : [];
+      return ok({ ...lite, layers, credits });
+    },
+
+    getItemCredits(id) {
+      if (!creditsStage.resolved) return err(loading("credits"));
+      const credits = itemCreditsStore?.[id];
+      return credits ? ok(credits) : err(notFound(id));
+    },
+
+    getItemLayers(id) {
+      if (!layersStage.resolved) return err(loading("layers"));
+      const layers = itemLayersStore?.[id];
+      return layers ? ok(layers) : err(notFound(id));
+    },
+
+    getPaletteMetadata() {
+      if (!paletteStage.resolved) return err(loading("palette"));
+      // Non-null by construction: registerFromPaletteModule sets the store
+      // before resolving the stage.
+      return ok(paletteMetadataStore!);
+    },
+
+    getCategoryTree() {
+      if (!indexStage.resolved) return err(loading("index"));
+      return ok(categoryTreeStore!);
+    },
+
+    getMetadataIndexes() {
+      if (!indexStage.resolved) return err(loading("index"));
+      return ok(metadataIndexesStore!);
+    },
+
+    getAliasMetadata() {
+      if (!indexStage.resolved) return err(loading("index"));
+      return ok(aliasMetadataStore!);
+    },
+
+    /**
+     * `byTypeName` for hash resolution when the index module is not registered
+     * yet. Rows match `buildSlimByTypeNameRow` (itemId, name, type_name,
+     * variants, recolors minimal array).
+     */
+    buildItemsByTypeNameFromRegisteredLite() {
+      if (!itemLiteStore) return {};
+      const synthetic: Record<string, ItemMerged> = {};
+      for (const [id, lite] of Object.entries(itemLiteStore)) {
+        synthetic[id] = { ...lite, layers: {}, credits: [] };
+      }
+      return buildItemsByTypeNameLite(synthetic) as Record<
+        string,
+        SlimByTypeNameRow[]
+      >;
+    },
+
+    // writer — only `install-item-metadata.ts` and test setup should call these
+    registerFromIndexModule(exports_) {
+      aliasMetadataStore = exports_.aliasMetadata;
+      categoryTreeStore = exports_.categoryTree;
+      metadataIndexesStore = expandMetadataIndexesWithInternedArrays(
+        exports_.metadataIndexes,
+      ) as MetadataIndexes;
+      indexStage.resolve();
+      expandInternedItemLitesInStore();
+    },
+
+    registerFromPaletteModule(exports_) {
+      paletteMetadataStore = exports_.paletteMetadata;
+      paletteStage.resolve();
+    },
+
+    registerFromItemModule(exports_) {
+      itemLiteStore = exports_.itemMetadata;
+      expandInternedItemLitesInStore();
+      liteStage.resolve();
+    },
+
+    registerFromCreditsModule(exports_) {
+      itemCreditsStore = exports_.itemCredits;
+      creditsStage.resolve();
+    },
+
+    registerFromLayersModule(exports_) {
+      itemLayersStore = exports_.itemLayers;
+      layersStage.resolve();
+    },
+
+    /**
+     * Loads the catalog from `extractMetadataGlobalsFromWrites` / `runBuild`
+     * `.globals` (merged `itemMetadata` is split into lite, credits, layers).
+     */
+    loadCatalogFromFixtures(fixtureGlobals) {
+      this.resetForTests();
+      const {
+        itemMetadata,
+        aliasMetadata,
+        categoryTree,
+        metadataIndexes,
+        paletteMetadata,
+      } = fixtureGlobals;
+      this.registerFromIndexModule({
+        aliasMetadata,
+        categoryTree,
+        metadataIndexes,
+      });
+      this.registerFromPaletteModule({ paletteMetadata });
+      const { itemMetadataLite, itemCredits, itemLayers } =
+        splitFullItemMetadataForCatalog(itemMetadata);
+      this.registerFromItemModule({ itemMetadata: itemMetadataLite });
+      this.registerFromCreditsModule({ itemCredits });
+      this.registerFromLayersModule({ itemLayers });
+    },
+
+    /**
+     * Reset to a fresh empty state. Used by tests that share `defaultCatalog`
+     * across cases. Tests can also construct a brand-new `createCatalog()` to
+     * sidestep this entirely.
+     */
+    resetForTests() {
+      indexStage = makeStage();
+      liteStage = makeStage();
+      creditsStage = makeStage();
+      paletteStage = makeStage();
+      layersStage = makeStage();
+
+      aliasMetadataStore = null;
+      categoryTreeStore = null;
+      metadataIndexesStore = null;
+      itemLiteStore = null;
+      itemCreditsStore = null;
+      itemLayersStore = null;
+      paletteMetadataStore = null;
+    },
+  };
 }
 
 // ────────────────────────────────────────────────────────────────────────────
-// Public: registers (called by `install-item-metadata.ts` after each chunk's
-// dynamic import resolves)
+// Default instance + legacy free-function exports (transitional)
 // ────────────────────────────────────────────────────────────────────────────
+//
+// All exports below preserve the pre-factory module surface for incremental
+// migration. They delegate to a single shared `defaultCatalog`. Phase Final
+// of the migration deletes everything between these comment fences; main.ts
+// will own the only `createCatalog()` instance at that point.
 
-export function registerFromIndexModule(exports_: {
+export const defaultCatalog: Catalog = createCatalog();
+
+export const catalogReady = defaultCatalog.ready;
+
+export const isIndexReady = (): boolean => defaultCatalog.isIndexReady();
+export const isLiteReady = (): boolean => defaultCatalog.isLiteReady();
+export const isCreditsReady = (): boolean => defaultCatalog.isCreditsReady();
+export const isPaletteReady = (): boolean => defaultCatalog.isPaletteReady();
+export const isLayersReady = (): boolean => defaultCatalog.isLayersReady();
+
+export const chunkReady = (chunk: ChunkName): Result<true, LoadError> =>
+  defaultCatalog.chunkReady(chunk);
+
+export const getItemLite = (id: string): Result<ItemLite, LoadError> =>
+  defaultCatalog.getItemLite(id);
+
+export const getItemMerged = (id: string): Result<ItemMerged, LoadError> =>
+  defaultCatalog.getItemMerged(id);
+
+export const getItemCredits = (id: string): Result<Credit[], LoadError> =>
+  defaultCatalog.getItemCredits(id);
+
+export const getItemLayers = (
+  id: string,
+): Result<Record<string, LayerEntry>, LoadError> =>
+  defaultCatalog.getItemLayers(id);
+
+export const getPaletteMetadata = (): Result<PaletteMetadata, LoadError> =>
+  defaultCatalog.getPaletteMetadata();
+
+export const getCategoryTree = (): Result<CategoryTree, LoadError> =>
+  defaultCatalog.getCategoryTree();
+
+export const getMetadataIndexes = (): Result<MetadataIndexes, LoadError> =>
+  defaultCatalog.getMetadataIndexes();
+
+export const getAliasMetadata = (): Result<AliasMetadata, LoadError> =>
+  defaultCatalog.getAliasMetadata();
+
+export const buildItemsByTypeNameFromRegisteredLite = (): Record<
+  string,
+  SlimByTypeNameRow[]
+> => defaultCatalog.buildItemsByTypeNameFromRegisteredLite();
+
+export const registerFromIndexModule = (exports_: {
   aliasMetadata: AliasMetadata;
   categoryTree: CategoryTree;
   metadataIndexes: MetadataIndexes;
-}): void {
-  aliasMetadataStore = exports_.aliasMetadata;
-  categoryTreeStore = exports_.categoryTree;
-  metadataIndexesStore = expandMetadataIndexesWithInternedArrays(
-    exports_.metadataIndexes,
-  ) as MetadataIndexes;
-  indexStage.resolve();
-  expandInternedItemLitesInStore();
-}
+}): void => defaultCatalog.registerFromIndexModule(exports_);
 
-export function registerFromPaletteModule(exports_: {
+export const registerFromPaletteModule = (exports_: {
   paletteMetadata: PaletteMetadata;
-}): void {
-  paletteMetadataStore = exports_.paletteMetadata;
-  paletteStage.resolve();
-}
+}): void => defaultCatalog.registerFromPaletteModule(exports_);
 
-export function registerFromItemModule(exports_: {
+export const registerFromItemModule = (exports_: {
   itemMetadata: Record<string, ItemLite>;
-}): void {
-  itemLiteStore = exports_.itemMetadata;
-  expandInternedItemLitesInStore();
-  liteStage.resolve();
-}
+}): void => defaultCatalog.registerFromItemModule(exports_);
 
-export function registerFromCreditsModule(exports_: {
+export const registerFromCreditsModule = (exports_: {
   itemCredits: Record<string, Credit[]>;
-}): void {
-  itemCreditsStore = exports_.itemCredits;
-  creditsStage.resolve();
-}
+}): void => defaultCatalog.registerFromCreditsModule(exports_);
 
-export function registerFromLayersModule(exports_: {
+export const registerFromLayersModule = (exports_: {
   itemLayers: Record<string, Record<string, LayerEntry>>;
-}): void {
-  itemLayersStore = exports_.itemLayers;
-  layersStage.resolve();
-}
+}): void => defaultCatalog.registerFromLayersModule(exports_);
 
-// ────────────────────────────────────────────────────────────────────────────
-// Public: hash-resolution helper
-// ────────────────────────────────────────────────────────────────────────────
-
-/**
- * `byTypeName` for hash resolution when the index module is not registered yet.
- * Rows match `buildSlimByTypeNameRow` (itemId, name, type_name, variants,
- * recolors minimal array).
- */
-export function buildItemsByTypeNameFromRegisteredLite(): Record<
-  string,
-  SlimByTypeNameRow[]
-> {
-  if (!itemLiteStore) return {};
-  const synthetic: Record<string, ItemMerged> = {};
-  for (const [id, lite] of Object.entries(itemLiteStore)) {
-    synthetic[id] = { ...lite, layers: {}, credits: [] };
-  }
-  return buildItemsByTypeNameLite(synthetic) as Record<
-    string,
-    SlimByTypeNameRow[]
-  >;
-}
-
-// ────────────────────────────────────────────────────────────────────────────
-// Public: test utilities
-// ────────────────────────────────────────────────────────────────────────────
-
-/**
- * Loads the catalog from `extractMetadataGlobalsFromWrites` / `runBuild`
- * `.globals` (merged `itemMetadata` is split into lite, credits, and layers).
- */
-export function loadCatalogFromFixtures(fixtureGlobals: {
+export const loadCatalogFromFixtures = (fixtureGlobals: {
   itemMetadata: Record<string, unknown>;
   aliasMetadata: AliasMetadata;
   categoryTree: CategoryTree;
   metadataIndexes: MetadataIndexes;
   paletteMetadata: PaletteMetadata;
-}): void {
-  resetCatalogForTests();
-  const {
-    itemMetadata,
-    aliasMetadata,
-    categoryTree,
-    metadataIndexes,
-    paletteMetadata,
-  } = fixtureGlobals;
-  registerFromIndexModule({ aliasMetadata, categoryTree, metadataIndexes });
-  registerFromPaletteModule({ paletteMetadata });
-  const { itemMetadataLite, itemCredits, itemLayers } =
-    splitFullItemMetadataForCatalog(itemMetadata);
-  registerFromItemModule({ itemMetadata: itemMetadataLite });
-  registerFromCreditsModule({ itemCredits });
-  registerFromLayersModule({ itemLayers });
-}
+}): void => defaultCatalog.loadCatalogFromFixtures(fixtureGlobals);
 
-// TODO: Replace module-level singletons with a `createCatalog()` factory + DI.
-// This reset exists only because catalog state lives at module scope; tests
-// have to scrub it between cases. With a factory, each test would construct
-// its own instance, consumers would receive the catalog via context (e.g. a
-// Mithril provider component or `state.catalog`) instead of importing it
-// directly, and this function would disappear. Defer until after the
-// Result-API migration lands so the consumer surface is already typed.
-export function resetCatalogForTests(): void {
-  indexStage = makeStage();
-  liteStage = makeStage();
-  creditsStage = makeStage();
-  paletteStage = makeStage();
-  layersStage = makeStage();
-
-  aliasMetadataStore = null;
-  categoryTreeStore = null;
-  metadataIndexesStore = null;
-  itemLiteStore = null;
-  itemCreditsStore = null;
-  itemLayersStore = null;
-  paletteMetadataStore = null;
-}
-
-// ────────────────────────────────────────────────────────────────────────────
-// Public: Result-returning getters
-// ────────────────────────────────────────────────────────────────────────────
-
-const loading = (chunk: ChunkName): LoadError => ({ kind: "loading", chunk });
-const notFound = (id: string): LoadError => ({ kind: "not-found", id });
-
-/**
- * Boundary primitive: returns `Ok(true)` once the named chunk has registered,
- * `Err({kind: "loading"})` otherwise. Use with `Result.combine` to gate a
- * subtree on a chunk that has no consumer-facing data getter (e.g. layers).
- */
-export function chunkReady(chunk: ChunkName): Result<true, LoadError> {
-  const stage = (
-    {
-      index: indexStage,
-      lite: liteStage,
-      credits: creditsStage,
-      palette: paletteStage,
-      layers: layersStage,
-    } as const
-  )[chunk];
-  return stage.resolved ? ok(true as const) : err(loading(chunk));
-}
-
-export function getItemLite(id: string): Result<ItemLite, LoadError> {
-  if (!liteStage.resolved) return err(loading("lite"));
-  const item = itemLiteStore?.[id];
-  return item ? ok(item) : err(notFound(id));
-}
-
-/**
- * "Best-effort" merge: returns Ok as soon as the lite chunk is ready, with
- * `layers` and `credits` defaulting to `{}` / `[]` when their chunks have not
- * loaded yet. This is intentional — it lets the UI render item names + tree
- * structure during the initial load while layers/credits stream in.
- *
- * Consumers that need to distinguish "loading" from "actually empty" should
- * use `getItemCredits` / `getItemLayers` directly (those are strict and
- * return `Err({kind:"loading"})` until their chunk lands), or compose via
- * `Result.combine` to wait on every needed chunk.
- */
-export function getItemMerged(id: string): Result<ItemMerged, LoadError> {
-  if (!liteStage.resolved) return err(loading("lite"));
-  const lite = itemLiteStore?.[id];
-  if (!lite) return err(notFound(id));
-  const layers = layersStage.resolved ? (itemLayersStore?.[id] ?? {}) : {};
-  const credits = creditsStage.resolved ? (itemCreditsStore?.[id] ?? []) : [];
-  return ok({ ...lite, layers, credits });
-}
-
-export function getItemCredits(id: string): Result<Credit[], LoadError> {
-  if (!creditsStage.resolved) return err(loading("credits"));
-  const credits = itemCreditsStore?.[id];
-  return credits ? ok(credits) : err(notFound(id));
-}
-
-export function getItemLayers(
-  id: string,
-): Result<Record<string, LayerEntry>, LoadError> {
-  if (!layersStage.resolved) return err(loading("layers"));
-  const layers = itemLayersStore?.[id];
-  return layers ? ok(layers) : err(notFound(id));
-}
-
-export function getPaletteMetadata(): Result<PaletteMetadata, LoadError> {
-  if (!paletteStage.resolved) return err(loading("palette"));
-  // Non-null by construction: registerFromPaletteModule sets the store before
-  // resolving the stage.
-  return ok(paletteMetadataStore!);
-}
-
-export function getCategoryTree(): Result<CategoryTree, LoadError> {
-  if (!indexStage.resolved) return err(loading("index"));
-  return ok(categoryTreeStore!);
-}
-
-export function getMetadataIndexes(): Result<MetadataIndexes, LoadError> {
-  if (!indexStage.resolved) return err(loading("index"));
-  return ok(metadataIndexesStore!);
-}
-
-export function getAliasMetadata(): Result<AliasMetadata, LoadError> {
-  if (!indexStage.resolved) return err(loading("index"));
-  return ok(aliasMetadataStore!);
-}
+// TODO (Catalog DI migration): once every consumer migrates to receive
+// `catalog: CatalogReader` via DI, drop this — tests will construct a fresh
+// `createCatalog()` per case instead of resetting a shared one.
+export const resetCatalogForTests = (): void => defaultCatalog.resetForTests();
 
 // ────────────────────────────────────────────────────────────────────────────
 // Boot-time globalThis shims (Playwright, Argos, dump-computed-styles)
@@ -531,7 +638,7 @@ if (typeof globalThis !== "undefined") {
   (
     globalThis as unknown as { __LPC_waitCatalogAllReady: () => Promise<void> }
   ).__LPC_waitCatalogAllReady = async () => {
-    await catalogReady.onAllReady;
+    await defaultCatalog.ready.onAllReady;
   };
   /**
    * Same gates as `PaletteSelectModal` (split metadata: palette + layers must
@@ -545,9 +652,9 @@ if (typeof globalThis !== "undefined") {
       __LPC_arePaletteModalMetadataChunksReady: () => boolean;
     }
   ).__LPC_arePaletteModalMetadataChunksReady = () =>
-    indexStage.resolved &&
-    liteStage.resolved &&
-    creditsStage.resolved &&
-    paletteStage.resolved &&
-    layersStage.resolved;
+    defaultCatalog.isIndexReady() &&
+    defaultCatalog.isLiteReady() &&
+    defaultCatalog.isCreditsReady() &&
+    defaultCatalog.isPaletteReady() &&
+    defaultCatalog.isLayersReady();
 }

--- a/tests/components/FiltersPanel_spec.js
+++ b/tests/components/FiltersPanel_spec.js
@@ -12,7 +12,8 @@ describe("FiltersPanel", () => {
   let vnode;
 
   beforeEach(() => {
-    vnode = FiltersPanel.view();
+    const catalog = { isLiteReady: () => true };
+    vnode = FiltersPanel.view({ attrs: { catalog } });
   });
 
   it("should render the CollapsibleSection component with correct attributes", () => {

--- a/tests/components/filters/AnimationFilters_spec.js
+++ b/tests/components/filters/AnimationFilters_spec.js
@@ -63,7 +63,10 @@ describe("AnimationFilters Component", () => {
     ).length;
     const totalCount = getAnimations().length;
 
-    m.render(container, m(AnimationFilters));
+    m.render(
+      container,
+      m(AnimationFilters, { catalog: { isLiteReady: () => true } }),
+    );
 
     const labelText = container.querySelector(
       ".tree-label .is-size-7",
@@ -82,7 +85,9 @@ describe("AnimationFilters Component", () => {
       anim1: true,
     };
 
-    m.mount(container, AnimationFilters);
+    m.mount(container, {
+      view: () => m(AnimationFilters, { catalog: { isLiteReady: () => true } }),
+    });
 
     const expandButton = container.querySelector("span.tree-arrow");
     expandButton.click(); // Expand to show content
@@ -110,7 +115,9 @@ describe("AnimationFilters Component", () => {
       anim1: true,
     };
 
-    m.mount(container, AnimationFilters);
+    m.mount(container, {
+      view: () => m(AnimationFilters, { catalog: { isLiteReady: () => true } }),
+    });
 
     const expandButton = container.querySelector("span.tree-arrow");
     expandButton.click(); // Expand to show content

--- a/tests/components/filters/LicenseFilters_spec.js
+++ b/tests/components/filters/LicenseFilters_spec.js
@@ -55,7 +55,12 @@ describe("LicenseFilters Component", () => {
     ).length;
     const totalCount = getLicenseConfig().length;
 
-    m.render(container, m(LicenseFilters));
+    m.render(
+      container,
+      m(LicenseFilters, {
+        catalog: { isLiteReady: () => true, isCreditsReady: () => true },
+      }),
+    );
 
     const labelText = container.querySelector(
       ".tree-label .is-size-7",
@@ -71,7 +76,12 @@ describe("LicenseFilters Component", () => {
     };
     state.enabledLicenses = { l1: true };
 
-    m.mount(container, LicenseFilters);
+    m.mount(container, {
+      view: () =>
+        m(LicenseFilters, {
+          catalog: { isLiteReady: () => true, isCreditsReady: () => true },
+        }),
+    });
 
     const expandButton = container.querySelector("span.tree-arrow");
     expandButton.click(); // Expand to show content
@@ -90,7 +100,12 @@ describe("LicenseFilters Component", () => {
     };
     state.enabledLicenses = { l1: true };
 
-    m.mount(container, LicenseFilters);
+    m.mount(container, {
+      view: () =>
+        m(LicenseFilters, {
+          catalog: { isLiteReady: () => true, isCreditsReady: () => true },
+        }),
+    });
 
     const expandButton = container.querySelector("span.tree-arrow");
     expandButton.click(); // Expand to show content

--- a/tests/components/filters/SearchControl_spec.js
+++ b/tests/components/filters/SearchControl_spec.js
@@ -24,7 +24,10 @@ describe("SearchControl", function () {
   });
 
   it("renders a search input field", function () {
-    m.render(container, m(SearchControl));
+    m.render(
+      container,
+      m(SearchControl, { catalog: { isLiteReady: () => true } }),
+    );
 
     // Should render an input with type=search and placeholder attribute
     const input = container.querySelector(
@@ -34,7 +37,10 @@ describe("SearchControl", function () {
   });
 
   it("displays the label 'Search:'", function () {
-    m.render(container, m(SearchControl));
+    m.render(
+      container,
+      m(SearchControl, { catalog: { isLiteReady: () => true } }),
+    );
 
     // Should have a label with text "Search:"
     assert.include(container.textContent, "Search:");
@@ -43,7 +49,10 @@ describe("SearchControl", function () {
   it("input reflects current state value", function () {
     const test_query = "test query";
     state.searchQuery = test_query;
-    m.render(container, m(SearchControl));
+    m.render(
+      container,
+      m(SearchControl, { catalog: { isLiteReady: () => true } }),
+    );
 
     // Input value should match state
     const input = container.querySelector("input");

--- a/tests/components/selections/CurrentSelections_spec.js
+++ b/tests/components/selections/CurrentSelections_spec.js
@@ -3,7 +3,10 @@ import { assert } from "chai";
 import { describe, it, beforeEach, afterEach } from "mocha-globals";
 import { CurrentSelections } from "../../../sources/components/selections/CurrentSelections.ts";
 import { state } from "../../../sources/state/state.ts";
-import { resetCatalogForTests } from "../../../sources/state/catalog.ts";
+import {
+  defaultCatalog,
+  resetCatalogForTests,
+} from "../../../sources/state/catalog.ts";
 import {
   resetState,
   setEnabledLicenses,
@@ -35,7 +38,7 @@ describe("CurrentSelections", function () {
   it("shows loading copy when item list (lite) is not ready", function () {
     resetCatalogForTests();
 
-    m.render(host, m(CurrentSelections));
+    m.render(host, m(CurrentSelections, { catalog: defaultCatalog }));
 
     assert.include(host.textContent, "Current Selections");
     assert.include(host.textContent, "Loading item list…");
@@ -54,7 +57,7 @@ describe("CurrentSelections", function () {
     });
     state.selections = {};
 
-    m.render(host, m(CurrentSelections));
+    m.render(host, m(CurrentSelections, { catalog: defaultCatalog }));
 
     assert.include(host.textContent, "No items selected yet");
     assert.strictEqual(host.querySelector(".tag"), null);
@@ -84,7 +87,7 @@ describe("CurrentSelections", function () {
       coat: { itemId: "sel_coat", name: "Winter Coat (long)" },
     };
 
-    m.render(host, m(CurrentSelections));
+    m.render(host, m(CurrentSelections, { catalog: defaultCatalog }));
 
     const heading = host.querySelector("h3.title");
     assert.notEqual(heading, null);
@@ -126,7 +129,7 @@ describe("CurrentSelections", function () {
       misc: { itemId: "sel_gpl_item", name: "GPL Asset" },
     };
 
-    m.render(host, m(CurrentSelections));
+    m.render(host, m(CurrentSelections, { catalog: defaultCatalog }));
 
     const tag = host.querySelector("span.tag.is-medium.is-warning");
     assert.notEqual(tag, null);
@@ -152,7 +155,7 @@ describe("CurrentSelections", function () {
       hat: { itemId: "sel_walk_only", name: "Walk Only" },
     };
 
-    m.render(host, m(CurrentSelections));
+    m.render(host, m(CurrentSelections, { catalog: defaultCatalog }));
 
     const tag = host.querySelector("span.tag.is-medium.is-warning");
     assert.notEqual(tag, null);
@@ -175,7 +178,7 @@ describe("CurrentSelections", function () {
       only: { itemId: "sel_a", name: "Item A" },
     };
 
-    m.render(host, m(CurrentSelections));
+    m.render(host, m(CurrentSelections, { catalog: defaultCatalog }));
 
     const del = host.querySelector("button.delete.is-small");
     assert.notEqual(del, null);
@@ -183,7 +186,7 @@ describe("CurrentSelections", function () {
 
     assert.deepEqual(state.selections, {});
     // `m.render` roots do not always redraw after inline handlers in tests; re-sync the tree.
-    m.render(host, m(CurrentSelections));
+    m.render(host, m(CurrentSelections, { catalog: defaultCatalog }));
     assert.include(host.textContent, "No items selected yet");
   });
 });

--- a/tests/components/tree/CategoryTree_spec.js
+++ b/tests/components/tree/CategoryTree_spec.js
@@ -4,6 +4,7 @@ import { describe, it, beforeEach, afterEach } from "mocha-globals";
 import { CategoryTree } from "../../../sources/components/tree/CategoryTree.ts";
 import { state } from "../../../sources/state/state.ts";
 import {
+  defaultCatalog,
   resetCatalogForTests,
   registerFromIndexModule,
   registerFromPaletteModule,
@@ -38,7 +39,7 @@ describe("CategoryTree", function () {
   it("shows loading panel until the category index is ready", function () {
     resetCatalogForTests();
 
-    m.render(host, m(CategoryTree));
+    m.render(host, m(CategoryTree, { catalog: defaultCatalog }));
 
     assert.ok(host.querySelector(".category-tree-loading-overlay"));
     assert.strictEqual(
@@ -66,7 +67,7 @@ describe("CategoryTree", function () {
       paletteMetadata: { versions: {}, materials: {} },
     });
 
-    m.render(host, m(CategoryTree));
+    m.render(host, m(CategoryTree, { catalog: defaultCatalog }));
 
     const expandBtn = [...host.querySelectorAll("button")].find(
       (b) => b.textContent.trim() === "Expand Selected",
@@ -100,7 +101,7 @@ describe("CategoryTree", function () {
     );
     state.expandedNodes.Gear = true;
 
-    m.render(host, m(CategoryTree));
+    m.render(host, m(CategoryTree, { catalog: defaultCatalog }));
 
     assert.strictEqual(
       host.querySelector("h3.title")?.textContent?.trim(),
@@ -170,7 +171,7 @@ describe("CategoryTree", function () {
     };
     state.expandedNodes = {};
 
-    m.render(host, m(CategoryTree));
+    m.render(host, m(CategoryTree, { catalog: defaultCatalog }));
 
     const expandBtn = [...host.querySelectorAll("button")].find(
       (b) => b.textContent.trim() === "Expand Selected",
@@ -205,7 +206,7 @@ describe("CategoryTree", function () {
     );
     state.expandedNodes = { Gear: true };
 
-    m.render(host, m(CategoryTree));
+    m.render(host, m(CategoryTree, { catalog: defaultCatalog }));
 
     const collapseBtn = [...host.querySelectorAll("button")].find(
       (b) => b.textContent.trim() === "Collapse All",

--- a/tests/components/tree/ItemWithRecolors_spec.js
+++ b/tests/components/tree/ItemWithRecolors_spec.js
@@ -3,7 +3,10 @@ import { assert } from "chai";
 import { describe, it, beforeEach, afterEach } from "mocha-globals";
 import { ItemWithRecolors } from "../../../sources/components/tree/ItemWithRecolors.ts";
 import { state } from "../../../sources/state/state.ts";
-import { getItemMerged } from "../../../sources/state/catalog.ts";
+import {
+  defaultCatalog,
+  getItemMerged,
+} from "../../../sources/state/catalog.ts";
 import { BODY_TYPES } from "../../../sources/state/constants.ts";
 import { resetState } from "../../../sources/state/filters.ts";
 import {
@@ -101,6 +104,7 @@ describe("ItemWithRecolors", function () {
       isCompatible: true,
       tooltipText: "tip",
       showItemTooltips: true,
+      catalog: defaultCatalog,
       ...overrides,
     };
   }
@@ -209,6 +213,7 @@ describe("ItemWithRecolors", function () {
         isCompatible: true,
         tooltipText: "",
         showItemTooltips: false,
+        catalog: defaultCatalog,
       }),
     );
 

--- a/tests/components/tree/PaletteSelectModal_spec.js
+++ b/tests/components/tree/PaletteSelectModal_spec.js
@@ -4,6 +4,7 @@ import { describe, it, beforeEach, afterEach } from "mocha-globals";
 import { PaletteSelectModal } from "../../../sources/components/tree/PaletteSelectModal.ts";
 import { state } from "../../../sources/state/state.ts";
 import {
+  defaultCatalog,
   isLayersReady,
   isLiteReady,
   isPaletteReady,
@@ -133,6 +134,7 @@ describe("PaletteSelectModal", function () {
       rootViewNode: rootViewNodeStub(),
       onClose: () => {},
       onSelect: () => {},
+      catalog: defaultCatalog,
     };
     return { ...base, ...overrides };
   }

--- a/tests/components/tree/TreeNode_spec.js
+++ b/tests/components/tree/TreeNode_spec.js
@@ -4,6 +4,7 @@ import { describe, it, beforeEach, afterEach } from "mocha-globals";
 import { TreeNode } from "../../../sources/components/tree/TreeNode.ts";
 import { state } from "../../../sources/state/state.ts";
 import {
+  defaultCatalog,
   resetCatalogForTests,
   registerFromIndexModule,
   registerFromPaletteModule,
@@ -58,7 +59,10 @@ describe("TreeNode", function () {
       children: {},
     };
 
-    m.render(host, m(TreeNode, { name: "Armor", node }));
+    m.render(
+      host,
+      m(TreeNode, { name: "Armor", node, catalog: defaultCatalog }),
+    );
 
     assert.strictEqual(host.querySelector(".tree-label"), null);
     assert.strictEqual(host.textContent.trim(), "");
@@ -80,6 +84,7 @@ describe("TreeNode", function () {
     m.render(
       host,
       m(TreeNode, {
+        catalog: defaultCatalog,
         name: "Headgear",
         node: { items: ["tn_alpha"], children: {} },
       }),
@@ -107,6 +112,7 @@ describe("TreeNode", function () {
     m.render(
       host,
       m(TreeNode, {
+        catalog: defaultCatalog,
         name: "Warehouse",
         node: { items: ["pending-id"], children: {} },
       }),
@@ -137,6 +143,7 @@ describe("TreeNode", function () {
     m.render(
       host,
       m(TreeNode, {
+        catalog: defaultCatalog,
         name: "outer_category",
         node: {
           label: "Custom Label",
@@ -156,6 +163,7 @@ describe("TreeNode", function () {
     m.render(
       host,
       m(TreeNode, {
+        catalog: defaultCatalog,
         name: "outer_category",
         node: {
           label: "Custom Label",
@@ -179,6 +187,7 @@ describe("TreeNode", function () {
     m.render(
       host,
       m(TreeNode, {
+        catalog: defaultCatalog,
         name: "armor",
         node: { items: [], children: {} },
       }),
@@ -203,6 +212,7 @@ describe("TreeNode", function () {
     m.render(
       host,
       m(TreeNode, {
+        catalog: defaultCatalog,
         name: "Gear",
         node: { items: ["tn_search_hat"], children: {} },
       }),
@@ -235,6 +245,7 @@ describe("TreeNode", function () {
     m.render(
       host,
       m(TreeNode, {
+        catalog: defaultCatalog,
         name: "capes",
         node: { items: ["tn_pick"], children: {} },
       }),
@@ -250,6 +261,7 @@ describe("TreeNode", function () {
     m.render(
       host,
       m(TreeNode, {
+        catalog: defaultCatalog,
         name: "capes",
         node: { items: ["tn_pick"], children: {} },
       }),
@@ -267,6 +279,7 @@ describe("TreeNode", function () {
     m.render(
       host,
       m(TreeNode, {
+        catalog: defaultCatalog,
         name: "AnimCat",
         node: {
           animations: ["walk"],
@@ -292,6 +305,7 @@ describe("TreeNode", function () {
     m.render(
       host,
       m(TreeNode, {
+        catalog: defaultCatalog,
         name: "parent",
         node: {
           items: [],


### PR DESCRIPTION
This shouldn't break anything. I am changing the catalog from a singleton to a dependency. This allows us to reason about what pieces we need in each component and to control concurrent mutations better by limiting accessors.
Once everything has been migrated, I will clean up the singleton. 