### PR TITLE
feat: Migrate path to use catalog DI

### DIFF
--- a/sources/canvas/canvas-utils.ts
+++ b/sources/canvas/canvas-utils.ts
@@ -63,7 +63,7 @@ export function hasContentInRegion(
 }
 
 export function getZPos(
-  catalog: Pick<CatalogReader, "getItemMerged">,
+  catalog: CatalogReader,
   itemId: string,
   layerNum: number = 1,
 ): number {

--- a/sources/canvas/palette-recolor.ts
+++ b/sources/canvas/palette-recolor.ts
@@ -10,10 +10,9 @@ import {
 import { debugLog, debugWarn } from "../utils/debug.ts";
 import { get2DContext } from "./canvas-utils.ts";
 import { getItemLite } from "../state/catalog.ts";
-import type { ItemMerged } from "../state/catalog.ts";
+import type { CatalogReader, ItemMerged } from "../state/catalog.ts";
 import { state } from "../state/state.ts";
 import { getLayersToLoad } from "../state/meta.ts";
-import type { LayersToLoadCatalog } from "../state/meta.ts";
 import { getPalettesFromMeta, getTargetPalette } from "../state/palettes.ts";
 import type { PaletteForItem } from "../state/palettes.ts";
 import { COMPACT_FRAME_SIZE, FRAME_SIZE } from "../state/constants.ts";
@@ -388,7 +387,7 @@ export async function recolorWithPalette(
  * for the tree/ migration; track separately.
  */
 export async function drawRecolorPreview(
-  catalog: LayersToLoadCatalog,
+  catalog: CatalogReader,
   itemId: string,
   meta: ItemMerged,
   canvas: HTMLCanvasElement,

--- a/sources/canvas/palette-recolor.ts
+++ b/sources/canvas/palette-recolor.ts
@@ -13,6 +13,7 @@ import { getItemLite } from "../state/catalog.ts";
 import type { ItemMerged } from "../state/catalog.ts";
 import { state } from "../state/state.ts";
 import { getLayersToLoad } from "../state/meta.ts";
+import type { LayersToLoadCatalog } from "../state/meta.ts";
 import { getPalettesFromMeta, getTargetPalette } from "../state/palettes.ts";
 import type { PaletteForItem } from "../state/palettes.ts";
 import { COMPACT_FRAME_SIZE, FRAME_SIZE } from "../state/constants.ts";
@@ -387,6 +388,7 @@ export async function recolorWithPalette(
  * for the tree/ migration; track separately.
  */
 export async function drawRecolorPreview(
+  catalog: LayersToLoadCatalog,
   itemId: string,
   meta: ItemMerged,
   canvas: HTMLCanvasElement,
@@ -413,7 +415,12 @@ export async function drawRecolorPreview(
     (meta as { preview_x_offset?: number }).preview_x_offset ?? 0;
   const previewYOffset =
     (meta as { preview_y_offset?: number }).preview_y_offset ?? 0;
-  const layersToLoad = getLayersToLoad(meta, state.bodyType, state.selections);
+  const layersToLoad = getLayersToLoad(
+    catalog,
+    meta,
+    state.bodyType,
+    state.selections,
+  );
 
   // Load and draw all layers
   let imagesLoaded = 0;

--- a/sources/canvas/renderer.ts
+++ b/sources/canvas/renderer.ts
@@ -334,6 +334,7 @@ async function runRenderCharacter(
           }
 
           const pathResult = getSpritePath(
+            defaultCatalog,
             itemId,
             variant ?? null,
             recolors,
@@ -793,6 +794,7 @@ export async function renderSingleItem(
       }
 
       const pathResult = getSpritePath(
+        defaultCatalog,
         itemId,
         variant,
         recolors,
@@ -944,6 +946,7 @@ export async function renderSingleItemAnimation(
     }
 
     const pathResult = getSpritePath(
+      defaultCatalog,
       itemId,
       variant,
       recolors,

--- a/sources/components/App.ts
+++ b/sources/components/App.ts
@@ -11,10 +11,10 @@ import { renderCharacter } from "../canvas/renderer.ts";
 
 /**
  * App is the composition root for catalog DI. main.ts mounts it with the
- * `defaultCatalog` instance; App threads narrow slices down to children that
- * have migrated to receive `catalog` via attrs (so far: FiltersPanel and its
- * subtree). Children that still import from `state/catalog.ts` directly are
- * unaffected — they read the same `defaultCatalog` state under the hood.
+ * `defaultCatalog` instance; App threads catalog down to children that have
+ * migrated to receive it via attrs. Children that still import from
+ * `state/catalog.ts` directly are unaffected — they read the same
+ * `defaultCatalog` state under the hood.
  */
 type AppAttrs = { catalog: CatalogReader };
 
@@ -46,7 +46,7 @@ export const App: m.Component<AppAttrs, AppState> = {
       currentCustomImage !== vnode.state.prevCustomImage ||
       currentCustomZPos !== vnode.state.prevCustomZPos
     ) {
-      syncSelectionsToHash();
+      syncSelectionsToHash(vnode.attrs.catalog);
       if (window.canvasRenderer) {
         // Render to offscreen canvas (async)
         renderCharacter(state.selections, state.bodyType).then(() => {
@@ -66,7 +66,7 @@ export const App: m.Component<AppAttrs, AppState> = {
     return m("div", [
       m(Download, { catalog: vnode.attrs.catalog }),
       m(FiltersPanel, { catalog: vnode.attrs.catalog }),
-      m(Credits),
+      m(Credits, { catalog: vnode.attrs.catalog }),
       m(AdvancedTools),
     ]);
   },

--- a/sources/components/download/Credits.ts
+++ b/sources/components/download/Credits.ts
@@ -5,13 +5,18 @@ import {
   getAllCredits,
   creditsToCsv,
   creditsToTxt,
+  type CreditsCatalog,
 } from "../../utils/credits.ts";
 import { CollapsibleSection } from "../CollapsibleSection.ts";
 import { downloadFile } from "../../canvas/download.ts";
 
-export const Credits: m.Component = {
-  view() {
-    const allCredits = getAllCredits(state.selections, state.bodyType);
+export const Credits: m.Component<{ catalog: CreditsCatalog }> = {
+  view(vnode) {
+    const allCredits = getAllCredits(
+      vnode.attrs.catalog,
+      state.selections,
+      state.bodyType,
+    );
 
     return m(
       CollapsibleSection,

--- a/sources/components/download/Credits.ts
+++ b/sources/components/download/Credits.ts
@@ -5,12 +5,12 @@ import {
   getAllCredits,
   creditsToCsv,
   creditsToTxt,
-  type CreditsCatalog,
 } from "../../utils/credits.ts";
 import { CollapsibleSection } from "../CollapsibleSection.ts";
 import { downloadFile } from "../../canvas/download.ts";
+import type { CatalogReader } from "../../state/catalog.ts";
 
-export const Credits: m.Component<{ catalog: CreditsCatalog }> = {
+export const Credits: m.Component<{ catalog: CatalogReader }> = {
   view(vnode) {
     const allCredits = getAllCredits(
       vnode.attrs.catalog,

--- a/sources/components/download/Download.ts
+++ b/sources/components/download/Download.ts
@@ -6,7 +6,6 @@ import {
   getAllCredits,
   creditsToCsv,
   creditsToTxt,
-  type CreditsCatalog,
 } from "../../utils/credits.ts";
 import { CollapsibleSection } from "../CollapsibleSection.ts";
 import { downloadFile, downloadAsPNG } from "../../canvas/download.ts";
@@ -14,7 +13,6 @@ import {
   importStateFromJSON,
   exportStateAsJSON,
   serializeLayersForJson,
-  type JsonExportCatalog,
 } from "../../state/json.ts";
 import {
   exportSplitAnimations,
@@ -27,11 +25,7 @@ import type { CatalogReader } from "../../state/catalog.ts";
 
 const zipExportTitle = "Wait for layer data to finish loading";
 
-type DownloadCatalog = Pick<CatalogReader, "isLayersReady"> &
-  CreditsCatalog &
-  JsonExportCatalog;
-
-export const Download: m.Component<{ catalog: DownloadCatalog }> = {
+export const Download: m.Component<{ catalog: CatalogReader }> = {
   view(vnode) {
     const zipDisabled = !vnode.attrs.catalog.isLayersReady();
 

--- a/sources/components/download/Download.ts
+++ b/sources/components/download/Download.ts
@@ -6,6 +6,7 @@ import {
   getAllCredits,
   creditsToCsv,
   creditsToTxt,
+  type CreditsCatalog,
 } from "../../utils/credits.ts";
 import { CollapsibleSection } from "../CollapsibleSection.ts";
 import { downloadFile, downloadAsPNG } from "../../canvas/download.ts";
@@ -13,6 +14,7 @@ import {
   importStateFromJSON,
   exportStateAsJSON,
   serializeLayersForJson,
+  type JsonExportCatalog,
 } from "../../state/json.ts";
 import {
   exportSplitAnimations,
@@ -25,11 +27,11 @@ import type { CatalogReader } from "../../state/catalog.ts";
 
 const zipExportTitle = "Wait for layer data to finish loading";
 
-type DownloadAttrs = {
-  catalog: Pick<CatalogReader, "isLayersReady">;
-};
+type DownloadCatalog = Pick<CatalogReader, "isLayersReady"> &
+  CreditsCatalog &
+  JsonExportCatalog;
 
-export const Download: m.Component<DownloadAttrs> = {
+export const Download: m.Component<{ catalog: DownloadCatalog }> = {
   view(vnode) {
     const zipDisabled = !vnode.attrs.catalog.isLayersReady();
 
@@ -37,6 +39,7 @@ export const Download: m.Component<DownloadAttrs> = {
       if (!window.canvasRenderer) return;
       try {
         const json = exportStateAsJSON(
+          vnode.attrs.catalog,
           state,
           serializeLayersForJson(drawCalls),
         );
@@ -90,6 +93,7 @@ export const Download: m.Component<DownloadAttrs> = {
             {
               onclick: () => {
                 const allCredits = getAllCredits(
+                  vnode.attrs.catalog,
                   state.selections,
                   state.bodyType,
                 );
@@ -104,6 +108,7 @@ export const Download: m.Component<DownloadAttrs> = {
             {
               onclick: () => {
                 const allCredits = getAllCredits(
+                  vnode.attrs.catalog,
                   state.selections,
                   state.bodyType,
                 );

--- a/sources/components/filters/AnimationFilters.ts
+++ b/sources/components/filters/AnimationFilters.ts
@@ -24,7 +24,7 @@ export function setAnimationCompatible(
 }
 export function isAnimationCompatible(
   itemId: string,
-  catalog: Pick<CatalogReader, "getItemLite">,
+  catalog: CatalogReader,
 ): boolean {
   return deps.isItemAnimationCompatible(itemId, catalog);
 }
@@ -38,7 +38,7 @@ export function getAnimations(): readonly AnimationOption[] {
 
 type AnimationFiltersState = { isExpanded: boolean };
 type AnimationFiltersAttrs = {
-  catalog: Pick<CatalogReader, "isLiteReady" | "getItemLite">;
+  catalog: CatalogReader;
 };
 
 export const AnimationFilters: m.Component<

--- a/sources/components/filters/LicenseFilters.ts
+++ b/sources/components/filters/LicenseFilters.ts
@@ -29,7 +29,7 @@ export function setLicenseCompatible(
 }
 export function isLicenseCompatible(
   itemId: string,
-  catalog: Pick<CatalogReader, "getItemMerged">,
+  catalog: CatalogReader,
 ): boolean {
   return deps.isItemLicenseCompatible(itemId, catalog);
 }
@@ -43,10 +43,7 @@ export function getLicenseConfig(): readonly LicenseOption[] {
 
 type LicenseFiltersState = { isExpanded: boolean };
 type LicenseFiltersAttrs = {
-  catalog: Pick<
-    CatalogReader,
-    "isLiteReady" | "isCreditsReady" | "getItemMerged"
-  >;
+  catalog: CatalogReader;
 };
 
 export const LicenseFilters: m.Component<

--- a/sources/components/filters/SearchControl.ts
+++ b/sources/components/filters/SearchControl.ts
@@ -4,7 +4,7 @@ import type { CatalogReader } from "../../state/catalog.ts";
 import { state } from "../../state/state.ts";
 
 type SearchControlAttrs = {
-  catalog: Pick<CatalogReader, "isLiteReady">;
+  catalog: CatalogReader;
 };
 
 export const SearchControl: m.Component<SearchControlAttrs> = {

--- a/sources/components/selections/CurrentSelections.ts
+++ b/sources/components/selections/CurrentSelections.ts
@@ -8,10 +8,7 @@ import {
 } from "../../state/filters.ts";
 
 type CurrentSelectionsAttrs = {
-  catalog: Pick<
-    CatalogReader,
-    "isLiteReady" | "isCreditsReady" | "getItemLite" | "getItemMerged"
-  >;
+  catalog: CatalogReader;
 };
 
 export const CurrentSelections: m.Component<CurrentSelectionsAttrs> = {

--- a/sources/components/tree/CategoryTree.ts
+++ b/sources/components/tree/CategoryTree.ts
@@ -12,13 +12,15 @@ import type {
 } from "../../state/catalog.ts";
 import { renderResult } from "../../utils/render-result.ts";
 import { BodyTypeSelector } from "./BodyTypeSelector.ts";
-import { TreeNode } from "./TreeNode.ts";
+import { TreeNode, type TreeNodeCatalog } from "./TreeNode.ts";
 
-// Forwarder: passes catalog down to TreeNode subtree. Declared as the full
-// reader (rather than a narrow Pick) because the transitive union of what its
-// descendants need covers most of CatalogReader anyway, and enumerating it
-// would make adding a downstream method an N-place edit. Leaves narrow.
-type CategoryTreeAttrs = { catalog: CatalogReader };
+type CategoryTreeCatalog = Pick<
+  CatalogReader,
+  "getCategoryTree" | "isLiteReady" | "getItemMerged"
+> &
+  TreeNodeCatalog;
+
+type CategoryTreeAttrs = { catalog: CategoryTreeCatalog };
 
 function renderLoadingHost() {
   return m("div.box.has-background-light.category-tree-panel", [
@@ -34,7 +36,10 @@ function renderLoadingHost() {
   ]);
 }
 
-function renderTree(categoryTree: CategoryTreeShape, catalog: CatalogReader) {
+function renderTree(
+  categoryTree: CategoryTreeShape,
+  catalog: CategoryTreeCatalog,
+) {
   const liteReady = catalog.isLiteReady();
 
   return m("div.box.has-background-light.category-tree-panel", [

--- a/sources/components/tree/CategoryTree.ts
+++ b/sources/components/tree/CategoryTree.ts
@@ -12,15 +12,9 @@ import type {
 } from "../../state/catalog.ts";
 import { renderResult } from "../../utils/render-result.ts";
 import { BodyTypeSelector } from "./BodyTypeSelector.ts";
-import { TreeNode, type TreeNodeCatalog } from "./TreeNode.ts";
+import { TreeNode } from "./TreeNode.ts";
 
-type CategoryTreeCatalog = Pick<
-  CatalogReader,
-  "getCategoryTree" | "isLiteReady" | "getItemMerged"
-> &
-  TreeNodeCatalog;
-
-type CategoryTreeAttrs = { catalog: CategoryTreeCatalog };
+type CategoryTreeAttrs = { catalog: CatalogReader };
 
 function renderLoadingHost() {
   return m("div.box.has-background-light.category-tree-panel", [
@@ -36,10 +30,7 @@ function renderLoadingHost() {
   ]);
 }
 
-function renderTree(
-  categoryTree: CategoryTreeShape,
-  catalog: CategoryTreeCatalog,
-) {
+function renderTree(categoryTree: CategoryTreeShape, catalog: CatalogReader) {
   const liteReady = catalog.isLiteReady();
 
   return m("div.box.has-background-light.category-tree-panel", [

--- a/sources/components/tree/ItemWithRecolors.ts
+++ b/sources/components/tree/ItemWithRecolors.ts
@@ -5,14 +5,8 @@ import { state, getSelectionGroup, selectItem } from "../../state/state.ts";
 import type { CatalogReader, ItemMerged } from "../../state/catalog.ts";
 import { drawRecolorPreview } from "../../canvas/palette-recolor.ts";
 import { getPaletteOptions } from "../../state/palettes.ts";
-import {
-  PaletteSelectModal,
-  type PaletteSelectModalCatalog,
-} from "./PaletteSelectModal.ts";
+import { PaletteSelectModal } from "./PaletteSelectModal.ts";
 import { COMPACT_FRAME_SIZE, FRAME_SIZE } from "../../state/constants.ts";
-
-export type ItemWithRecolorsCatalog = Pick<CatalogReader, "isPaletteReady"> &
-  PaletteSelectModalCatalog;
 
 export type ItemWithRecolorsAttrs = {
   itemId: string;
@@ -21,7 +15,7 @@ export type ItemWithRecolorsAttrs = {
   isCompatible: boolean;
   tooltipText: string;
   showItemTooltips?: boolean;
-  catalog: ItemWithRecolorsCatalog;
+  catalog: CatalogReader;
 };
 
 type ItemWithRecolorsState = {

--- a/sources/components/tree/ItemWithRecolors.ts
+++ b/sources/components/tree/ItemWithRecolors.ts
@@ -5,11 +5,15 @@ import { state, getSelectionGroup, selectItem } from "../../state/state.ts";
 import type { CatalogReader, ItemMerged } from "../../state/catalog.ts";
 import { drawRecolorPreview } from "../../canvas/palette-recolor.ts";
 import { getPaletteOptions } from "../../state/palettes.ts";
-import { PaletteSelectModal } from "./PaletteSelectModal.ts";
+import {
+  PaletteSelectModal,
+  type PaletteSelectModalCatalog,
+} from "./PaletteSelectModal.ts";
 import { COMPACT_FRAME_SIZE, FRAME_SIZE } from "../../state/constants.ts";
 
-// Forwarder: own use is just `isPaletteReady`, but it forwards a wider slice
-// to PaletteSelectModal. Full reader keeps the contract simple; leaf narrows.
+export type ItemWithRecolorsCatalog = Pick<CatalogReader, "isPaletteReady"> &
+  PaletteSelectModalCatalog;
+
 export type ItemWithRecolorsAttrs = {
   itemId: string;
   meta: ItemMerged;
@@ -17,7 +21,7 @@ export type ItemWithRecolorsAttrs = {
   isCompatible: boolean;
   tooltipText: string;
   showItemTooltips?: boolean;
-  catalog: CatalogReader;
+  catalog: ItemWithRecolorsCatalog;
 };
 
 type ItemWithRecolorsState = {
@@ -161,6 +165,7 @@ export const ItemWithRecolors: m.Component<
                           cs.renderId = renderId;
                           cs.lastColorsKey = JSON.stringify(selectedColors);
                           drawRecolorPreview(
+                            catalog,
                             itemId,
                             meta,
                             canvas,
@@ -180,6 +185,7 @@ export const ItemWithRecolors: m.Component<
                           const renderId = (cs.renderId ?? 0) + 1;
                           cs.renderId = renderId;
                           drawRecolorPreview(
+                            catalog,
                             itemId,
                             meta,
                             canvas,
@@ -287,6 +293,7 @@ export const ItemWithRecolors: m.Component<
                           oncreate: async (canvasVnode: m.VnodeDOM) => {
                             const canvas = canvasVnode.dom as HTMLCanvasElement;
                             const imagesLoaded = await drawRecolorPreview(
+                              catalog,
                               itemId,
                               meta,
                               canvas,
@@ -307,6 +314,7 @@ export const ItemWithRecolors: m.Component<
                             }
                             const canvas = canvasVnode.dom as HTMLCanvasElement;
                             const imagesLoaded = await drawRecolorPreview(
+                              catalog,
                               itemId,
                               meta,
                               canvas,

--- a/sources/components/tree/ItemWithVariants.ts
+++ b/sources/components/tree/ItemWithVariants.ts
@@ -3,10 +3,12 @@ import m from "mithril";
 import classNames from "classnames";
 import { state, getSelectionGroup, selectItem } from "../../state/state.ts";
 import { getLayersToLoad } from "../../state/meta.ts";
-import type { LayerToLoad } from "../../state/meta.ts";
+import type { LayerToLoad, LayersToLoadCatalog } from "../../state/meta.ts";
 import { COMPACT_FRAME_SIZE, FRAME_SIZE } from "../../state/constants.ts";
 import { capitalize } from "../../utils/helpers.ts";
 import type { ItemMerged } from "../../state/catalog.ts";
+
+export type ItemWithVariantsCatalog = LayersToLoadCatalog;
 
 export type ItemWithVariantsAttrs = {
   itemId: string;
@@ -15,6 +17,7 @@ export type ItemWithVariantsAttrs = {
   isCompatible: boolean;
   tooltipText: string;
   showItemTooltips?: boolean;
+  catalog: ItemWithVariantsCatalog;
 };
 
 type ItemWithVariantsState = {
@@ -39,6 +42,7 @@ export const ItemWithVariants: m.Component<
       isCompatible,
       tooltipText,
       showItemTooltips = true,
+      catalog,
     } = vnode.attrs;
     const rowTitle = showItemTooltips ? tooltipText : undefined;
     const compactDisplay = state.compactDisplay;
@@ -49,7 +53,12 @@ export const ItemWithVariants: m.Component<
       nodePath = "body-body";
     }
     const isExpanded = state.expandedNodes[nodePath] || false;
-    const layers = getLayersToLoad(meta, state.bodyType, state.selections);
+    const layers = getLayersToLoad(
+      catalog,
+      meta,
+      state.bodyType,
+      state.selections,
+    );
 
     return m(
       "div",
@@ -174,6 +183,7 @@ export const ItemWithVariants: m.Component<
 
                           // Get Layers to Load for Variant
                           const layersToLoad = getLayersToLoad(
+                            catalog,
                             meta,
                             state.bodyType,
                             state.selections,

--- a/sources/components/tree/ItemWithVariants.ts
+++ b/sources/components/tree/ItemWithVariants.ts
@@ -3,12 +3,10 @@ import m from "mithril";
 import classNames from "classnames";
 import { state, getSelectionGroup, selectItem } from "../../state/state.ts";
 import { getLayersToLoad } from "../../state/meta.ts";
-import type { LayerToLoad, LayersToLoadCatalog } from "../../state/meta.ts";
+import type { LayerToLoad } from "../../state/meta.ts";
 import { COMPACT_FRAME_SIZE, FRAME_SIZE } from "../../state/constants.ts";
 import { capitalize } from "../../utils/helpers.ts";
-import type { ItemMerged } from "../../state/catalog.ts";
-
-export type ItemWithVariantsCatalog = LayersToLoadCatalog;
+import type { CatalogReader, ItemMerged } from "../../state/catalog.ts";
 
 export type ItemWithVariantsAttrs = {
   itemId: string;
@@ -17,7 +15,7 @@ export type ItemWithVariantsAttrs = {
   isCompatible: boolean;
   tooltipText: string;
   showItemTooltips?: boolean;
-  catalog: ItemWithVariantsCatalog;
+  catalog: CatalogReader;
 };
 
 type ItemWithVariantsState = {

--- a/sources/components/tree/PaletteSelectModal.ts
+++ b/sources/components/tree/PaletteSelectModal.ts
@@ -8,18 +8,11 @@ import type {
   PaletteMetadata,
   LoadError,
 } from "../../state/catalog.ts";
-import type { LayersToLoadCatalog } from "../../state/meta.ts";
 import { renderResult } from "../../utils/render-result.ts";
 import { state, getSelectionGroup } from "../../state/state.ts";
 import { ucwords } from "../../utils/helpers.ts";
 import { COMPACT_FRAME_SIZE, FRAME_SIZE } from "../../state/constants.ts";
 import type { PaletteOption } from "../../state/palettes.ts";
-
-export type PaletteSelectModalCatalog = Pick<
-  CatalogReader,
-  "chunkReady" | "getItemMerged" | "getPaletteMetadata"
-> &
-  LayersToLoadCatalog;
 
 type RootViewState = {
   palettePreviewGateSeq?: number;
@@ -43,7 +36,7 @@ export type PaletteSelectModalAttrs = {
   rootViewNode: RootViewRef;
   onClose: () => void;
   onSelect: (recolor: string) => void;
-  catalog: PaletteSelectModalCatalog;
+  catalog: CatalogReader;
 };
 
 /**

--- a/sources/components/tree/PaletteSelectModal.ts
+++ b/sources/components/tree/PaletteSelectModal.ts
@@ -8,16 +8,18 @@ import type {
   PaletteMetadata,
   LoadError,
 } from "../../state/catalog.ts";
+import type { LayersToLoadCatalog } from "../../state/meta.ts";
 import { renderResult } from "../../utils/render-result.ts";
 import { state, getSelectionGroup } from "../../state/state.ts";
 import { ucwords } from "../../utils/helpers.ts";
 import { COMPACT_FRAME_SIZE, FRAME_SIZE } from "../../state/constants.ts";
 import type { PaletteOption } from "../../state/palettes.ts";
 
-type PaletteSelectModalCatalog = Pick<
+export type PaletteSelectModalCatalog = Pick<
   CatalogReader,
   "chunkReady" | "getItemMerged" | "getPaletteMetadata"
->;
+> &
+  LayersToLoadCatalog;
 
 type RootViewState = {
   palettePreviewGateSeq?: number;
@@ -116,6 +118,7 @@ function renderModal(
     rootViewNode,
     onClose,
     onSelect,
+    catalog,
   } = attrs;
 
   const selectionGroup = opt.type_name ?? getSelectionGroup(itemId);
@@ -253,6 +256,7 @@ function renderModal(
                                   const settledGate =
                                     rootViewNode.state.palettePreviewGateSeq;
                                   void drawRecolorPreview(
+                                    catalog,
                                     itemId,
                                     meta,
                                     canvas,

--- a/sources/components/tree/TreeNode.ts
+++ b/sources/components/tree/TreeNode.ts
@@ -17,12 +17,28 @@ import {
   matchesSearch,
   nodeHasMatches,
 } from "../../utils/helpers.ts";
-import { ItemWithVariants } from "./ItemWithVariants.ts";
-import { ItemWithRecolors } from "./ItemWithRecolors.ts";
+import {
+  ItemWithVariants,
+  type ItemWithVariantsCatalog,
+} from "./ItemWithVariants.ts";
+import {
+  ItemWithRecolors,
+  type ItemWithRecolorsCatalog,
+} from "./ItemWithRecolors.ts";
 
-// Forwarder: catalog flows to ItemWithRecolors → PaletteSelectModal. Full
-// reader avoids enumerating the transitive union of downstream needs. The
-// leaf (PaletteSelectModal) narrows.
+// Forwarder: catalog flows through variant/recolor preview paths; compose the
+// direct tree needs with the child component needs.
+export type TreeNodeCatalog = Pick<
+  CatalogReader,
+  | "getItemLite"
+  | "getItemMerged"
+  | "getItemCredits"
+  | "isLiteReady"
+  | "isCreditsReady"
+> &
+  ItemWithVariantsCatalog &
+  ItemWithRecolorsCatalog;
+
 export type TreeNodeAttrs = {
   name: string;
   node: CategoryTreeNode & {
@@ -31,13 +47,13 @@ export type TreeNodeAttrs = {
     label?: string;
   };
   pathPrefix?: string;
-  catalog: CatalogReader;
+  catalog: TreeNodeCatalog;
 };
 
 type ItemListCtx = {
   isNodeAnimCompatible: boolean;
   searchQuery: string;
-  catalog: CatalogReader;
+  catalog: TreeNodeCatalog;
 };
 
 function renderSkeletons(itemIds: string[]) {
@@ -151,6 +167,7 @@ function renderItem(itemId: string, meta: ItemMerged, ctx: ItemListCtx) {
     isCompatible,
     tooltipText,
     showItemTooltips,
+    catalog,
   });
 }
 

--- a/sources/components/tree/TreeNode.ts
+++ b/sources/components/tree/TreeNode.ts
@@ -17,27 +17,8 @@ import {
   matchesSearch,
   nodeHasMatches,
 } from "../../utils/helpers.ts";
-import {
-  ItemWithVariants,
-  type ItemWithVariantsCatalog,
-} from "./ItemWithVariants.ts";
-import {
-  ItemWithRecolors,
-  type ItemWithRecolorsCatalog,
-} from "./ItemWithRecolors.ts";
-
-// Forwarder: catalog flows through variant/recolor preview paths; compose the
-// direct tree needs with the child component needs.
-export type TreeNodeCatalog = Pick<
-  CatalogReader,
-  | "getItemLite"
-  | "getItemMerged"
-  | "getItemCredits"
-  | "isLiteReady"
-  | "isCreditsReady"
-> &
-  ItemWithVariantsCatalog &
-  ItemWithRecolorsCatalog;
+import { ItemWithVariants } from "./ItemWithVariants.ts";
+import { ItemWithRecolors } from "./ItemWithRecolors.ts";
 
 export type TreeNodeAttrs = {
   name: string;
@@ -47,13 +28,13 @@ export type TreeNodeAttrs = {
     label?: string;
   };
   pathPrefix?: string;
-  catalog: TreeNodeCatalog;
+  catalog: CatalogReader;
 };
 
 type ItemListCtx = {
   isNodeAnimCompatible: boolean;
   searchQuery: string;
-  catalog: TreeNodeCatalog;
+  catalog: CatalogReader;
 };
 
 function renderSkeletons(itemIds: string[]) {

--- a/sources/state/filters.ts
+++ b/sources/state/filters.ts
@@ -129,7 +129,7 @@ export function getAllowedLicenses(): string[] {
 /** Whether an item's credits include at least one license that's currently enabled. */
 export function isItemLicenseCompatible(
   itemId: string,
-  catalog: Pick<CatalogReader, "getItemMerged">,
+  catalog: CatalogReader,
 ): boolean {
   const result = catalog.getItemMerged(itemId);
   if (result.isErr()) return true; // chunk loading or unknown id — assume compatible
@@ -156,7 +156,7 @@ export function isItemLicenseCompatible(
 /** Whether an item supports at least one currently-enabled animation. */
 export function isItemAnimationCompatible(
   itemId: string,
-  catalog: Pick<CatalogReader, "getItemLite">,
+  catalog: CatalogReader,
 ): boolean {
   const meta = catalog.getItemLite(itemId).unwrapOr(null);
   if (!meta) return true; // unknown item — assume compatible

--- a/sources/state/hash.ts
+++ b/sources/state/hash.ts
@@ -18,11 +18,6 @@ import {
 } from "./catalog.ts";
 import { resolveHashParamFromHashMatch } from "./resolve-hash-param.ts";
 
-export type HashParamsCatalog = Pick<
-  CatalogReader,
-  "getAliasMetadata" | "getItemLite"
->;
-
 /**
  * Outcome of resolving a `typeName`/`nameAndVariant` pair against the
  * catalog. `foundItemId` is null when no match was made.
@@ -214,7 +209,7 @@ export function buildNewSelection(
 }
 
 export function getHashParamsforSelections(
-  catalog: HashParamsCatalog,
+  catalog: CatalogReader,
   selections: Selections,
 ): Record<string, string> {
   const params: Record<string, string> = {};
@@ -282,7 +277,7 @@ export function getHashParamsforSelections(
   return params;
 }
 
-export function syncSelectionsToHash(catalog: HashParamsCatalog): void {
+export function syncSelectionsToHash(catalog: CatalogReader): void {
   const params = getHashParamsforSelections(catalog, state.selections);
   setHashParams(params);
 }

--- a/sources/state/hash.ts
+++ b/sources/state/hash.ts
@@ -5,16 +5,23 @@ import { parseRecolorKey } from "./palettes.ts";
 import { debugWarn } from "../utils/debug.ts";
 import {
   buildItemsByTypeNameFromRegisteredLite,
+  defaultCatalog,
   getAliasMetadata,
   getItemLite,
   getMetadataIndexes,
   isIndexReady,
   isLiteReady,
   type AliasMetadata,
+  type CatalogReader,
   type ItemLite,
   type SlimByTypeNameRow,
 } from "./catalog.ts";
 import { resolveHashParamFromHashMatch } from "./resolve-hash-param.ts";
+
+export type HashParamsCatalog = Pick<
+  CatalogReader,
+  "getAliasMetadata" | "getItemLite"
+>;
 
 /**
  * Outcome of resolving a `typeName`/`nameAndVariant` pair against the
@@ -207,6 +214,7 @@ export function buildNewSelection(
 }
 
 export function getHashParamsforSelections(
+  catalog: HashParamsCatalog,
   selections: Selections,
 ): Record<string, string> {
   const params: Record<string, string> = {};
@@ -216,9 +224,11 @@ export function getHashParamsforSelections(
 
   // Add selections — old format: `type_name=Name_variant`.
   // e.g., "body=Body_color_light", "shoes=Sara_sara".
-  const aliasMetadata = getAliasMetadata().unwrapOr({} as AliasMetadata);
+  const aliasMetadata = catalog
+    .getAliasMetadata()
+    .unwrapOr({} as AliasMetadata);
   for (const [typeName, selection] of Object.entries(selections)) {
-    const meta = getItemLite(selection.itemId).unwrapOr(null);
+    const meta = catalog.getItemLite(selection.itemId).unwrapOr(null);
     // Defensive: real production data has type_name, but a few test fixtures
     // (and possibly malformed URLs) might lack it. Treat as alias-fallback.
     if (!meta || !meta.type_name) {
@@ -272,8 +282,8 @@ export function getHashParamsforSelections(
   return params;
 }
 
-export function syncSelectionsToHash(): void {
-  const params = getHashParamsforSelections(state.selections);
+export function syncSelectionsToHash(catalog: HashParamsCatalog): void {
+  const params = getHashParamsforSelections(catalog, state.selections);
   setHashParams(params);
 }
 
@@ -416,7 +426,7 @@ export function loadSelectionsFromHash(hashString: string | null = null): void {
   }
 
   // Ensure hash is in sync with loaded selections (handles any normalization).
-  syncSelectionsToHash();
+  syncSelectionsToHash(defaultCatalog);
 
   if (profiler) {
     profiler.mark("hash-loadSelectionsFromHash:end");

--- a/sources/state/json.ts
+++ b/sources/state/json.ts
@@ -2,14 +2,12 @@ import {
   createHashStringFromParams,
   getHashParamsforSelections,
   loadSelectionsFromHash,
-  type HashParamsCatalog,
 } from "./hash.ts";
-import { getAllCredits, type CreditsCatalog } from "../utils/credits.ts";
+import { getAllCredits } from "../utils/credits.ts";
 import { state } from "./state.ts";
 import type { Selections, State } from "./state.ts";
 import type { DrawCall } from "../canvas/renderer.ts";
-
-export type JsonExportCatalog = HashParamsCatalog & CreditsCatalog;
+import type { CatalogReader } from "./catalog.ts";
 
 /** Shape of a layer as it appears in the exported `character.json` manifest.
  *  The live `HTMLImageElement` carried by `DrawCall.source` for custom uploads
@@ -79,12 +77,12 @@ type CreditsByFile = ReturnType<typeof getAllCredits>;
 type JsonDeps = {
   createHashStringFromParams: (params: Record<string, string>) => string;
   getHashParamsforSelections: (
-    catalog: HashParamsCatalog,
+    catalog: CatalogReader,
     selections: Selections,
   ) => Record<string, string>;
   loadSelectionsFromHash: (hashString?: string | null) => void;
   getAllCredits: (
-    catalog: CreditsCatalog,
+    catalog: CatalogReader,
     selections: Selections,
     bodyType: string,
   ) => CreditsByFile;
@@ -127,7 +125,7 @@ export function getJsonDeps(): JsonDeps {
  * needs is "an array of JSON-serializable values."
  */
 export function exportStateAsJSON(
-  catalog: JsonExportCatalog,
+  catalog: CatalogReader,
   state: State,
   layers: readonly unknown[],
 ): string {

--- a/sources/state/json.ts
+++ b/sources/state/json.ts
@@ -2,11 +2,14 @@ import {
   createHashStringFromParams,
   getHashParamsforSelections,
   loadSelectionsFromHash,
+  type HashParamsCatalog,
 } from "./hash.ts";
-import { getAllCredits } from "../utils/credits.ts";
+import { getAllCredits, type CreditsCatalog } from "../utils/credits.ts";
 import { state } from "./state.ts";
 import type { Selections, State } from "./state.ts";
 import type { DrawCall } from "../canvas/renderer.ts";
+
+export type JsonExportCatalog = HashParamsCatalog & CreditsCatalog;
 
 /** Shape of a layer as it appears in the exported `character.json` manifest.
  *  The live `HTMLImageElement` carried by `DrawCall.source` for custom uploads
@@ -76,10 +79,15 @@ type CreditsByFile = ReturnType<typeof getAllCredits>;
 type JsonDeps = {
   createHashStringFromParams: (params: Record<string, string>) => string;
   getHashParamsforSelections: (
+    catalog: HashParamsCatalog,
     selections: Selections,
   ) => Record<string, string>;
   loadSelectionsFromHash: (hashString?: string | null) => void;
-  getAllCredits: (selections: Selections, bodyType: string) => CreditsByFile;
+  getAllCredits: (
+    catalog: CreditsCatalog,
+    selections: Selections,
+    bodyType: string,
+  ) => CreditsByFile;
   getLocationOrigin: () => string;
   getLocationPathname: () => string;
 };
@@ -119,11 +127,12 @@ export function getJsonDeps(): JsonDeps {
  * needs is "an array of JSON-serializable values."
  */
 export function exportStateAsJSON(
+  catalog: JsonExportCatalog,
   state: State,
   layers: readonly unknown[],
 ): string {
   const hash = jsonDeps.createHashStringFromParams(
-    jsonDeps.getHashParamsforSelections(state.selections),
+    jsonDeps.getHashParamsforSelections(catalog, state.selections),
   );
   const url = `${jsonDeps.getLocationOrigin()}${jsonDeps.getLocationPathname()}#${hash}`;
   const exportedState = {
@@ -139,7 +148,7 @@ export function exportStateAsJSON(
     enabledAnimations: state.enabledAnimations,
     url,
     layers,
-    credits: jsonDeps.getAllCredits(state.selections, state.bodyType),
+    credits: jsonDeps.getAllCredits(catalog, state.selections, state.bodyType),
   };
   return JSON.stringify(exportedState, null, 2);
 }

--- a/sources/state/meta.ts
+++ b/sources/state/meta.ts
@@ -1,6 +1,6 @@
 import { ok, type Result } from "neverthrow";
 import { variantToFilename } from "../utils/helpers.ts";
-import { replaceInPath } from "./path.ts";
+import { replaceInPath, type ReplaceInPathCatalog } from "./path.ts";
 import {
   type CatalogReader,
   type ItemMerged,
@@ -9,6 +9,7 @@ import {
 import type { Selections } from "./state.ts";
 
 type MetaCatalog = Pick<CatalogReader, "getItemMerged">;
+export type LayersToLoadCatalog = ReplaceInPathCatalog;
 
 export type SortedLayer = { layerNum: number; zPos: number };
 export type AnimationLayer = SortedLayer & { animLayerNum: number };
@@ -113,6 +114,7 @@ export function getSortedLayersByAnim(
  * are omitted if missing).
  */
 export function getLayersToLoad(
+  catalog: LayersToLoadCatalog,
   meta: ItemMerged,
   bodyType: string,
   selections: Selections,
@@ -142,7 +144,7 @@ export function getLayersToLoad(
 
     // Replace template variables like ${head}.
     if (layerPath.includes("${")) {
-      layerPath = replaceInPath(layerPath, selections, meta);
+      layerPath = replaceInPath(catalog, layerPath, selections, meta);
     }
 
     const hasCustomAnim = layer.custom_animation;

--- a/sources/state/meta.ts
+++ b/sources/state/meta.ts
@@ -1,15 +1,12 @@
 import { ok, type Result } from "neverthrow";
 import { variantToFilename } from "../utils/helpers.ts";
-import { replaceInPath, type ReplaceInPathCatalog } from "./path.ts";
+import { replaceInPath } from "./path.ts";
 import {
   type CatalogReader,
   type ItemMerged,
   type LoadError,
 } from "./catalog.ts";
 import type { Selections } from "./state.ts";
-
-type MetaCatalog = Pick<CatalogReader, "getItemMerged">;
-export type LayersToLoadCatalog = ReplaceInPathCatalog;
 
 export type SortedLayer = { layerNum: number; zPos: number };
 export type AnimationLayer = SortedLayer & { animLayerNum: number };
@@ -31,7 +28,7 @@ export type LayerToLoad = { zPos: number; path: string };
 
 /** Sort layers by zPos. */
 export function getSortedLayers(
-  catalog: MetaCatalog,
+  catalog: CatalogReader,
   itemId: string,
   standardOnly: boolean = false,
 ): Result<SortedLayer[], LoadError> {
@@ -57,7 +54,7 @@ export function getSortedLayers(
  * (custom-animation-only items), fall back to all layers.
  */
 export function getSortedLayersWithCustomFallback(
-  catalog: MetaCatalog,
+  catalog: CatalogReader,
   itemId: string,
 ): Result<SortedLayer[], LoadError> {
   return getSortedLayers(catalog, itemId, true).andThen((layers) =>
@@ -67,7 +64,7 @@ export function getSortedLayersWithCustomFallback(
 
 /** Split layers by animation type, then sort by zPos. */
 export function getSortedLayersByAnim(
-  catalog: MetaCatalog,
+  catalog: CatalogReader,
   itemId: string,
   customOnly: boolean = false,
 ): Result<Record<string, AnimationLayer[]>, LoadError> {
@@ -114,7 +111,7 @@ export function getSortedLayersByAnim(
  * are omitted if missing).
  */
 export function getLayersToLoad(
-  catalog: LayersToLoadCatalog,
+  catalog: CatalogReader,
   meta: ItemMerged,
   bodyType: string,
   selections: Selections,

--- a/sources/state/path.ts
+++ b/sources/state/path.ts
@@ -1,7 +1,7 @@
 import "../install-item-metadata.ts";
 import { ok, err, type Result } from "neverthrow";
 import { ANIMATIONS } from "./constants.ts";
-import { getHashParamsforSelections, type HashParamsCatalog } from "./hash.ts";
+import { getHashParamsforSelections } from "./hash.ts";
 import {
   type CatalogReader,
   type ItemMerged,
@@ -23,12 +23,6 @@ import type { AnimationEntry } from "./filters.ts";
 type PathMeta = Partial<ItemMerged> & {
   replace_in_path?: Record<string, Record<string, string>>;
 };
-
-export type ReplaceInPathCatalog = HashParamsCatalog &
-  Pick<CatalogReader, "getMetadataIndexes">;
-
-export type SpritePathCatalog = ReplaceInPathCatalog &
-  Pick<CatalogReader, "getItemMerged">;
 
 /** Subset of `SlimByTypeNameRow` consumed by `getNameWithoutVariant`. */
 type NameVariantRow = {
@@ -120,7 +114,7 @@ export function getNameWithoutVariant(
 
 /** Build a sprite-path string for a specific item layer + animation + variant. */
 export function getSpritePath(
-  catalog: SpritePathCatalog,
+  catalog: CatalogReader,
   itemId: string,
   variant: string | null,
   recolors: Record<string, string> | boolean | null,
@@ -166,7 +160,7 @@ export function getSpritePath(
 
 /** Replace `${typeName}` placeholders in a path using the current selections. */
 export function replaceInPath(
-  catalog: ReplaceInPathCatalog,
+  catalog: CatalogReader,
   path: string,
   selections: Selections | null | undefined,
   meta: PathMeta,
@@ -197,7 +191,7 @@ export function replaceInPath(
 }
 
 function _getNameWithoutVariant(
-  catalog: ReplaceInPathCatalog,
+  catalog: CatalogReader,
   typeName: string,
   nameAndVariant: string,
 ): string {

--- a/sources/state/path.ts
+++ b/sources/state/path.ts
@@ -1,13 +1,11 @@
 import "../install-item-metadata.ts";
 import { ok, err, type Result } from "neverthrow";
 import { ANIMATIONS } from "./constants.ts";
-import { getHashParamsforSelections } from "./hash.ts";
+import { getHashParamsforSelections, type HashParamsCatalog } from "./hash.ts";
 import {
-  getItemMerged,
-  getMetadataIndexes,
+  type CatalogReader,
   type ItemMerged,
   type LoadError,
-  type MetadataIndexes,
   type SlimByTypeNameRow,
 } from "./catalog.ts";
 import { variantToFilename, es6DynamicTemplate } from "../utils/helpers.ts";
@@ -26,6 +24,12 @@ type PathMeta = Partial<ItemMerged> & {
   replace_in_path?: Record<string, Record<string, string>>;
 };
 
+export type ReplaceInPathCatalog = HashParamsCatalog &
+  Pick<CatalogReader, "getMetadataIndexes">;
+
+export type SpritePathCatalog = ReplaceInPathCatalog &
+  Pick<CatalogReader, "getItemMerged">;
+
 /** Subset of `SlimByTypeNameRow` consumed by `getNameWithoutVariant`. */
 type NameVariantRow = {
   variants?: string[];
@@ -43,9 +47,6 @@ export type PathError =
   | { kind: "missing-bodytype-path"; bodyType: string };
 
 type PathDeps = {
-  getHashParamsforSelections: (
-    selections: Selections,
-  ) => Record<string, string>;
   variantToFilename: (variant: string) => string;
   es6DynamicTemplate: (
     template: string,
@@ -53,20 +54,14 @@ type PathDeps = {
   ) => string;
   debugLog: (message: string) => void;
   animations: AnimationEntry[];
-  /** Result-returning lookups; callers `.unwrapOr(...)` at the use site. */
-  getItemMetadata: (itemId: string) => Result<PathMeta, LoadError>;
-  getMetadataIndexes: () => Result<MetadataIndexes, LoadError>;
 };
 
 function createDefaultPathDeps(): PathDeps {
   return {
-    getHashParamsforSelections,
     variantToFilename,
     es6DynamicTemplate,
     debugLog,
     animations: ANIMATIONS,
-    getItemMetadata: getItemMerged,
-    getMetadataIndexes,
   };
 }
 
@@ -125,6 +120,7 @@ export function getNameWithoutVariant(
 
 /** Build a sprite-path string for a specific item layer + animation + variant. */
 export function getSpritePath(
+  catalog: SpritePathCatalog,
   itemId: string,
   variant: string | null,
   recolors: Record<string, string> | boolean | null,
@@ -135,7 +131,7 @@ export function getSpritePath(
   meta: PathMeta | null = null,
 ): Result<string, PathError> {
   if (!meta) {
-    const r = pathDeps.getItemMetadata(itemId);
+    const r = catalog.getItemMerged(itemId);
     if (r.isErr()) return err(r.error);
     meta = r.value;
   }
@@ -148,7 +144,7 @@ export function getSpritePath(
   if (!basePath) return err({ kind: "missing-bodytype-path", bodyType });
 
   if (basePath.includes("${")) {
-    basePath = replaceInPath(basePath, selections, meta);
+    basePath = replaceInPath(catalog, basePath, selections, meta);
   }
 
   // If no variant specified, try to extract from itemId.
@@ -170,6 +166,7 @@ export function getSpritePath(
 
 /** Replace `${typeName}` placeholders in a path using the current selections. */
 export function replaceInPath(
+  catalog: ReplaceInPathCatalog,
   path: string,
   selections: Selections | null | undefined,
   meta: PathMeta,
@@ -177,10 +174,10 @@ export function replaceInPath(
   if (path.includes("${")) {
     // TODO: optimize — recomputed on every layer/frame today; could be cached
     // per-selection-change or skipped when `path` doesn't contain `${`.
-    const hashParams = pathDeps.getHashParamsforSelections(selections || {});
+    const hashParams = getHashParamsforSelections(catalog, selections || {});
     const replacements = Object.fromEntries(
       Object.entries(hashParams).map(([typeName, nameAndVariant]) => {
-        const name = _getNameWithoutVariant(typeName, nameAndVariant);
+        const name = _getNameWithoutVariant(catalog, typeName, nameAndVariant);
         // `meta.replace_in_path` may be undefined; preserved JS behavior is to
         // throw when the path has placeholders but the field is missing.
         const replacement = meta.replace_in_path![typeName]?.[name];
@@ -200,10 +197,11 @@ export function replaceInPath(
 }
 
 function _getNameWithoutVariant(
+  catalog: ReplaceInPathCatalog,
   typeName: string,
   nameAndVariant: string,
 ): string {
-  const indexes = pathDeps.getMetadataIndexes().unwrapOr(null);
+  const indexes = catalog.getMetadataIndexes().unwrapOr(null);
   const itemsForType = indexes?.byTypeName?.[typeName] ?? [];
   return getNameWithoutVariant(nameAndVariant, itemsForType);
 }

--- a/sources/state/state.ts
+++ b/sources/state/state.ts
@@ -2,7 +2,7 @@
 import m from "mithril";
 import { LICENSE_CONFIG, ANIMATIONS, BODY_TYPES } from "./constants.ts";
 import { syncSelectionsToHash, loadSelectionsFromHash } from "./hash.ts";
-import { getItemMerged, type ItemMerged } from "./catalog.ts";
+import { defaultCatalog, getItemMerged, type ItemMerged } from "./catalog.ts";
 import { renderCharacter } from "../canvas/renderer.ts";
 
 /** A single item selection within a selection group (e.g. body, head, ears). */
@@ -80,7 +80,7 @@ function createDefaultStateDeps(): StateDeps {
     getItemMetadata: (itemId) => getItemMerged(itemId).unwrapOr(null),
     selectDefaults,
     redraw: () => m.redraw(),
-    syncSelectionsToHash,
+    syncSelectionsToHash: () => syncSelectionsToHash(defaultCatalog),
     renderCharacter,
     loadSelectionsFromHash,
     getCanvasRenderer: () =>

--- a/sources/state/zip.ts
+++ b/sources/state/zip.ts
@@ -175,7 +175,13 @@ export const exportSplitAnimations = async (
     }
 
     await profiler.phase("staticFiles", async () => {
-      addCharacterJsonAndCredits(zip, creditsFolder, state!, drawCalls);
+      addCharacterJsonAndCredits(
+        defaultCatalog,
+        zip,
+        creditsFolder,
+        state!,
+        drawCalls,
+      );
     });
 
     const metadata = {
@@ -298,7 +304,13 @@ export const exportSplitItemSheets = async (
     }
 
     await profiler.phase("staticFiles", async () => {
-      addCharacterJsonAndCredits(zip, creditsFolder, state!, drawCalls);
+      addCharacterJsonAndCredits(
+        defaultCatalog,
+        zip,
+        creditsFolder,
+        state!,
+        drawCalls,
+      );
     });
 
     const zipBlob = await zipGenerateBlobWithProfiler(profiler, zip);
@@ -555,7 +567,13 @@ export const exportSplitItemAnimations = async (
     }
 
     await profiler.phase("staticFiles", async () => {
-      addCharacterJsonAndCredits(zip, creditsFolder, state!, drawCalls);
+      addCharacterJsonAndCredits(
+        defaultCatalog,
+        zip,
+        creditsFolder,
+        state!,
+        drawCalls,
+      );
     });
 
     const metadata = {
@@ -861,7 +879,13 @@ export const exportIndividualFrames = async (
     );
 
     await profiler.phase("staticFiles", async () => {
-      addCharacterJsonAndCredits(zip, creditsFolder, state!, drawCalls);
+      addCharacterJsonAndCredits(
+        defaultCatalog,
+        zip,
+        creditsFolder,
+        state!,
+        drawCalls,
+      );
     });
 
     const metadata = {

--- a/sources/utils/credits.ts
+++ b/sources/utils/credits.ts
@@ -3,19 +3,17 @@
 import type { CatalogReader, Credit } from "../state/catalog.ts";
 import { state } from "../state/state.ts";
 import type { Selections } from "../state/state.ts";
-import { replaceInPath, type ReplaceInPathCatalog } from "../state/path.ts";
+import { replaceInPath } from "../state/path.ts";
 import { variantToFilename } from "../utils/helpers.ts";
 
 type CreditWithFileName = Credit & { fileName: string };
-export type CreditsCatalog = Pick<CatalogReader, "getItemMerged"> &
-  ReplaceInPathCatalog;
 
 /**
  * Collect credits from all selected items. Only includes credits for files
  * actually being used based on current bodyType.
  */
 export function getAllCredits(
-  catalog: CreditsCatalog,
+  catalog: CatalogReader,
   selections: Selections,
   bodyType: string,
 ): CreditWithFileName[] {

--- a/sources/utils/credits.ts
+++ b/sources/utils/credits.ts
@@ -1,18 +1,21 @@
 // Credit collection and formatting utilities
 
-import { getItemMerged, type Credit } from "../state/catalog.ts";
+import type { CatalogReader, Credit } from "../state/catalog.ts";
 import { state } from "../state/state.ts";
 import type { Selections } from "../state/state.ts";
-import { replaceInPath } from "../state/path.ts";
+import { replaceInPath, type ReplaceInPathCatalog } from "../state/path.ts";
 import { variantToFilename } from "../utils/helpers.ts";
 
 type CreditWithFileName = Credit & { fileName: string };
+export type CreditsCatalog = Pick<CatalogReader, "getItemMerged"> &
+  ReplaceInPathCatalog;
 
 /**
  * Collect credits from all selected items. Only includes credits for files
  * actually being used based on current bodyType.
  */
 export function getAllCredits(
+  catalog: CreditsCatalog,
   selections: Selections,
   bodyType: string,
 ): CreditWithFileName[] {
@@ -21,7 +24,7 @@ export function getAllCredits(
 
   for (const [, selection] of Object.entries(selections)) {
     const { itemId } = selection;
-    const metaResult = getItemMerged(itemId);
+    const metaResult = catalog.getItemMerged(itemId);
     if (metaResult.isErr()) continue;
     const meta = metaResult.value;
     if (meta.credits.length === 0) continue;
@@ -42,7 +45,7 @@ export function getAllCredits(
       if (!basePath) continue;
 
       // Replace template variables like ${head} if present
-      basePath = replaceInPath(basePath, selections, meta);
+      basePath = replaceInPath(catalog, basePath, selections, meta);
 
       const animation =
         (state.selectedAnimation as string | undefined) ??

--- a/sources/utils/helpers.ts
+++ b/sources/utils/helpers.ts
@@ -43,7 +43,7 @@ export function matchesSearch(text: string, query: string): boolean {
 export function nodeHasMatches(
   node: CategoryTreeNode,
   query: string,
-  catalog: Pick<CatalogReader, "isLiteReady" | "getItemLite">,
+  catalog: CatalogReader,
 ): boolean {
   if (!query || query.length < 2) return true;
 

--- a/sources/utils/zip-helpers.ts
+++ b/sources/utils/zip-helpers.ts
@@ -16,22 +16,12 @@ import {
   hasContentInRegion,
 } from "../canvas/canvas-utils.ts";
 import { debugLog, debugWarn } from "../utils/debug.ts";
-import {
-  getAllCredits,
-  creditsToTxt,
-  creditsToCsv,
-  type CreditsCatalog,
-} from "./credits.ts";
-import {
-  exportStateAsJSON,
-  serializeLayersForJson,
-  type JsonExportCatalog,
-} from "../state/json.ts";
+import { getAllCredits, creditsToTxt, creditsToCsv } from "./credits.ts";
+import { exportStateAsJSON, serializeLayersForJson } from "../state/json.ts";
 import type { ZipExportProfiler } from "../performance-profiler.ts";
 import type { State } from "../state/state.ts";
 import type { DrawCall } from "../canvas/renderer.ts";
-
-type ZipMetadataCatalog = JsonExportCatalog & CreditsCatalog;
+import type { CatalogReader } from "../state/catalog.ts";
 
 /**
  * Subset of the JSZip folder API consumed by these helpers and downstream
@@ -591,7 +581,7 @@ export function guardZipExportEnvironment(): boolean {
  * Writes `character.json` at zip root and `credits.txt` / `credits.csv` under `creditsFolder`.
  */
 export function addCharacterJsonAndCredits(
-  catalog: ZipMetadataCatalog,
+  catalog: CatalogReader,
   zip: ZipFolder,
   creditsFolder: ZipFolder,
   state: State,

--- a/sources/utils/zip-helpers.ts
+++ b/sources/utils/zip-helpers.ts
@@ -16,11 +16,22 @@ import {
   hasContentInRegion,
 } from "../canvas/canvas-utils.ts";
 import { debugLog, debugWarn } from "../utils/debug.ts";
-import { getAllCredits, creditsToTxt, creditsToCsv } from "./credits.ts";
-import { exportStateAsJSON, serializeLayersForJson } from "../state/json.ts";
+import {
+  getAllCredits,
+  creditsToTxt,
+  creditsToCsv,
+  type CreditsCatalog,
+} from "./credits.ts";
+import {
+  exportStateAsJSON,
+  serializeLayersForJson,
+  type JsonExportCatalog,
+} from "../state/json.ts";
 import type { ZipExportProfiler } from "../performance-profiler.ts";
 import type { State } from "../state/state.ts";
 import type { DrawCall } from "../canvas/renderer.ts";
+
+type ZipMetadataCatalog = JsonExportCatalog & CreditsCatalog;
 
 /**
  * Subset of the JSZip folder API consumed by these helpers and downstream
@@ -580,6 +591,7 @@ export function guardZipExportEnvironment(): boolean {
  * Writes `character.json` at zip root and `credits.txt` / `credits.csv` under `creditsFolder`.
  */
 export function addCharacterJsonAndCredits(
+  catalog: ZipMetadataCatalog,
   zip: ZipFolder,
   creditsFolder: ZipFolder,
   state: State,
@@ -587,9 +599,9 @@ export function addCharacterJsonAndCredits(
 ): void {
   zip.file(
     "character.json",
-    exportStateAsJSON(state, serializeLayersForJson(drawCalls)),
+    exportStateAsJSON(catalog, state, serializeLayersForJson(drawCalls)),
   );
-  const allCredits = getAllCredits(state.selections, state.bodyType);
+  const allCredits = getAllCredits(catalog, state.selections, state.bodyType);
   creditsFolder.file("credits.txt", creditsToTxt(allCredits));
   creditsFolder.file("credits.csv", creditsToCsv(allCredits));
 }

--- a/tests/components/tree/ItemWithVariants_spec.js
+++ b/tests/components/tree/ItemWithVariants_spec.js
@@ -3,7 +3,10 @@ import { assert } from "chai";
 import { describe, it, beforeEach, afterEach } from "mocha-globals";
 import { ItemWithVariants } from "../../../sources/components/tree/ItemWithVariants.ts";
 import { state } from "../../../sources/state/state.ts";
-import { getItemMerged } from "../../../sources/state/catalog.ts";
+import {
+  defaultCatalog,
+  getItemMerged,
+} from "../../../sources/state/catalog.ts";
 import { BODY_TYPES } from "../../../sources/state/constants.ts";
 import { resetState } from "../../../sources/state/filters.ts";
 import {
@@ -61,6 +64,7 @@ describe("ItemWithVariants", function () {
         isCompatible: true,
         tooltipText: "Licenses: CC0\nAnimations: walk",
         showItemTooltips: true,
+        catalog: defaultCatalog,
       }),
     );
 
@@ -83,6 +87,7 @@ describe("ItemWithVariants", function () {
         isCompatible: false,
         tooltipText: "⚠️ Incompatible\nAnimations: walk",
         showItemTooltips: true,
+        catalog: defaultCatalog,
       }),
     );
 
@@ -105,6 +110,7 @@ describe("ItemWithVariants", function () {
         isCompatible: true,
         tooltipText: "tip",
         showItemTooltips: true,
+        catalog: defaultCatalog,
       }),
     );
 
@@ -149,6 +155,7 @@ describe("ItemWithVariants", function () {
         isCompatible: true,
         tooltipText: "",
         showItemTooltips: false,
+        catalog: defaultCatalog,
       }),
     );
 
@@ -171,6 +178,7 @@ describe("ItemWithVariants", function () {
         isCompatible: true,
         tooltipText: "tip",
         showItemTooltips: true,
+        catalog: defaultCatalog,
       }),
     );
     state.expandedNodes.iwv_cloak = true;
@@ -183,6 +191,7 @@ describe("ItemWithVariants", function () {
         isCompatible: true,
         tooltipText: "tip",
         showItemTooltips: true,
+        catalog: defaultCatalog,
       }),
     );
 
@@ -207,6 +216,7 @@ describe("ItemWithVariants", function () {
         isCompatible: true,
         tooltipText: "tip",
         showItemTooltips: true,
+        catalog: defaultCatalog,
       }),
     );
     host
@@ -230,6 +240,7 @@ describe("ItemWithVariants", function () {
         isCompatible: false,
         tooltipText: "bad",
         showItemTooltips: true,
+        catalog: defaultCatalog,
       }),
     );
 
@@ -255,6 +266,7 @@ describe("ItemWithVariants", function () {
         isCompatible: true,
         tooltipText: "tip",
         showItemTooltips: true,
+        catalog: defaultCatalog,
       }),
     );
 

--- a/tests/state/hash_spec.js
+++ b/tests/state/hash_spec.js
@@ -19,7 +19,10 @@ import {
   resetHashCalledTimes,
   resetHashDeps,
 } from "../../sources/state/hash.ts";
-import { resetCatalogForTests } from "../../sources/state/catalog.ts";
+import {
+  defaultCatalog,
+  resetCatalogForTests,
+} from "../../sources/state/catalog.ts";
 import {
   restoreAppCatalogAfterTest,
   seedBrowserCatalog,
@@ -121,7 +124,10 @@ describe("state/hash.ts", () => {
         1: { type_name: "body", name: "Body", variants: ["light"] },
       });
 
-      const params = getHashParamsforSelections(getState().selections);
+      const params = getHashParamsforSelections(
+        defaultCatalog,
+        getState().selections,
+      );
       expect(params).to.deep.equal({
         sex: "male",
         body: "Body_light",
@@ -145,7 +151,10 @@ describe("state/hash.ts", () => {
         },
       });
 
-      const params = getHashParamsforSelections(getState().selections);
+      const params = getHashParamsforSelections(
+        defaultCatalog,
+        getState().selections,
+      );
       expect(params).to.deep.equal({
         sex: "male",
         body: "Body_light",
@@ -177,7 +186,10 @@ describe("state/hash.ts", () => {
         },
       });
 
-      const params = getHashParamsforSelections(getState().selections);
+      const params = getHashParamsforSelections(
+        defaultCatalog,
+        getState().selections,
+      );
       expect(params).to.deep.equal({
         sex: "male",
         body: "Body_light",
@@ -198,7 +210,7 @@ describe("state/hash.ts", () => {
         1: { type_name: "body", name: "Body", variants: ["light"] },
       });
 
-      syncSelectionsToHash();
+      syncSelectionsToHash(defaultCatalog);
       expect(getSetHashCalledTimes()).to.equal(1);
     });
   });

--- a/tests/state/json_spec.js
+++ b/tests/state/json_spec.js
@@ -7,6 +7,7 @@ import {
 import { expect } from "chai";
 import sinon from "sinon";
 import { describe, it, beforeEach, afterEach } from "mocha-globals";
+import { defaultCatalog } from "../../sources/state/catalog.ts";
 
 describe("state/json.ts", () => {
   beforeEach(() => {
@@ -37,7 +38,9 @@ describe("state/json.ts", () => {
         enabledLicenses: { CC0: true },
         enabledAnimations: { walk: false },
       };
-      const out = exportStateAsJSON(snapshot, [{ zPos: 1, path: "p" }]);
+      const out = exportStateAsJSON(defaultCatalog, snapshot, [
+        { zPos: 1, path: "p" },
+      ]);
       const parsed = JSON.parse(out);
       expect(parsed.version).to.equal(2);
       expect(parsed.url).to.equal("https://example.com/lpc/#sex=male");

--- a/tests/state/meta_spec.js
+++ b/tests/state/meta_spec.js
@@ -4,7 +4,7 @@ import {
   getSortedLayersByAnim,
   getSortedLayersWithCustomFallback,
 } from "../../sources/state/meta.ts";
-import { setPathDeps, resetPathDeps } from "../../sources/state/path.ts";
+import { resetPathDeps } from "../../sources/state/path.ts";
 import { createCatalog, defaultCatalog } from "../../sources/state/catalog.ts";
 import { err } from "neverthrow";
 import { expect } from "chai";
@@ -231,9 +231,9 @@ describe("state/meta.ts", () => {
           },
         },
       };
-      expect(getLayersToLoad(meta, "male", {}, null)).to.deep.equal([
-        { zPos: 10, path: "spritesheets/armor/male/walk.png" },
-      ]);
+      expect(
+        getLayersToLoad(defaultCatalog, meta, "male", {}, null),
+      ).to.deep.equal([{ zPos: 10, path: "spritesheets/armor/male/walk.png" }]);
     });
 
     it("uses the first animation when walk is not present", () => {
@@ -246,9 +246,9 @@ describe("state/meta.ts", () => {
           },
         },
       };
-      expect(getLayersToLoad(meta, "male", {}, null)).to.deep.equal([
-        { zPos: 1, path: "spritesheets/x/idle.png" },
-      ]);
+      expect(
+        getLayersToLoad(defaultCatalog, meta, "male", {}, null),
+      ).to.deep.equal([{ zPos: 1, path: "spritesheets/x/idle.png" }]);
     });
 
     it("appends variant filename for standard layers under the default animation", () => {
@@ -261,7 +261,9 @@ describe("state/meta.ts", () => {
           },
         },
       };
-      expect(getLayersToLoad(meta, "male", {}, "light brown")).to.deep.equal([
+      expect(
+        getLayersToLoad(defaultCatalog, meta, "male", {}, "light brown"),
+      ).to.deep.equal([
         {
           zPos: 10,
           path: "spritesheets/armor/male/walk/light_brown.png",
@@ -280,14 +282,16 @@ describe("state/meta.ts", () => {
           },
         },
       };
-      expect(getLayersToLoad(meta, "male", {}, "red")).to.deep.equal([
-        { zPos: 5, path: "spritesheets/custom/base/red.png" },
-      ]);
+      expect(
+        getLayersToLoad(defaultCatalog, meta, "male", {}, "red"),
+      ).to.deep.equal([{ zPos: 5, path: "spritesheets/custom/base/red.png" }]);
     });
 
     it("replaces template variables when the layer path contains ${}", () => {
-      setPathDeps({
-        getHashParamsforSelections: () => ({ head: "human_head" }),
+      const catalog = createCatalogWithItem("headItem", {
+        type_name: "head",
+        name: "human",
+        variants: ["head"],
       });
       const meta = {
         animations: ["walk"],
@@ -301,7 +305,13 @@ describe("state/meta.ts", () => {
           },
         },
       };
-      const out = getLayersToLoad(meta, "male", {}, "v");
+      const out = getLayersToLoad(
+        catalog,
+        meta,
+        "male",
+        { head: { itemId: "headItem", variant: "head" } },
+        "v",
+      );
       expect(out).to.deep.equal([
         { zPos: 0, path: "spritesheets/pre/resolved/walk/v.png" },
       ]);
@@ -321,7 +331,7 @@ describe("state/meta.ts", () => {
           },
         },
       };
-      const out = getLayersToLoad(meta, "male", {}, null);
+      const out = getLayersToLoad(defaultCatalog, meta, "male", {}, null);
       expect(out.map((o) => o.zPos)).to.deep.equal([10, 50]);
     });
 
@@ -342,7 +352,9 @@ describe("state/meta.ts", () => {
       };
       // layer_2: no matching custom_animation vs layer_1. layer_1: custom layers need a
       // variant to form a loadable path; without one, nothing to load.
-      expect(getLayersToLoad(meta, "male", {}, null)).to.deep.equal([]);
+      expect(
+        getLayersToLoad(defaultCatalog, meta, "male", {}, null),
+      ).to.deep.equal([]);
     });
 
     it("skips layers whose body type has no path", () => {
@@ -355,7 +367,9 @@ describe("state/meta.ts", () => {
           },
         },
       };
-      expect(getLayersToLoad(meta, "male", {}, null)).to.deep.equal([]);
+      expect(
+        getLayersToLoad(defaultCatalog, meta, "male", {}, null),
+      ).to.deep.equal([]);
     });
   });
 });

--- a/tests/state/path_spec.js
+++ b/tests/state/path_spec.js
@@ -6,10 +6,13 @@ import {
   resetPathDeps,
 } from "../../sources/state/path.ts";
 import {
-  loadCatalogFromFixtures,
+  defaultCatalog,
   resetCatalogForTests,
 } from "../../sources/state/catalog.ts";
-import { restoreAppCatalogAfterTest } from "../browser-catalog-fixture.js";
+import {
+  restoreAppCatalogAfterTest,
+  seedBrowserCatalog,
+} from "../browser-catalog-fixture.js";
 import { es6DynamicTemplate } from "../../sources/utils/helpers.ts";
 import { err } from "neverthrow";
 import { expect } from "chai";
@@ -21,6 +24,30 @@ describe("state/path.ts", () => {
     resetCatalogForTests();
     resetPathDeps();
   });
+
+  function seedTemplateCatalog() {
+    seedBrowserCatalog({
+      headItem: {
+        type_name: "head",
+        name: "human",
+        variants: ["head"],
+        layers: {},
+        credits: [],
+      },
+      bodyItem: {
+        type_name: "body",
+        name: "shirt",
+        variants: ["red"],
+        layers: {},
+        credits: [],
+      },
+    });
+  }
+
+  const templateSelections = {
+    head: { itemId: "headItem", variant: "head" },
+    body: { itemId: "bodyItem", variant: "red" },
+  };
 
   afterEach(async () => {
     resetPathDeps();
@@ -67,70 +94,32 @@ describe("state/path.ts", () => {
   describe("replaceInPath", () => {
     it("returns the path unchanged when it has no template placeholders", () => {
       const meta = { replace_in_path: {} };
-      expect(replaceInPath("sprites/foo/bar", {}, meta)).to.equal(
-        "sprites/foo/bar",
-      );
+      expect(
+        replaceInPath(defaultCatalog, "sprites/foo/bar", {}, meta),
+      ).to.equal("sprites/foo/bar");
     });
 
-    it("resolves ${} segments using stubbed hash params and meta.replace_in_path", () => {
-      setPathDeps({
-        getHashParamsforSelections: () => ({ head: "human_head" }),
-      });
+    it("resolves ${} segments using catalog hash params and meta.replace_in_path", () => {
+      seedTemplateCatalog();
       const meta = {
         replace_in_path: {
           head: { human: "humanoid" },
         },
       };
-      expect(replaceInPath("base/${head}/tail", {}, meta)).to.equal(
-        "base/humanoid/tail",
-      );
-    });
-
-    it("resolves ${} using catalog byTypeName for name stripping", () => {
-      loadCatalogFromFixtures({
-        itemMetadata: {
-          x: {
-            type_name: "head",
-            name: "Human",
-            variants: ["head", "red"],
-            layers: {},
-            credits: [],
-          },
-        },
-        aliasMetadata: {},
-        categoryTree: { items: [], children: {} },
-        metadataIndexes: {
-          byTypeName: {
-            head: [
-              {
-                itemId: "x",
-                type_name: "head",
-                name: "Human",
-                variants: ["head", "red"],
-                recolors: [],
-              },
-            ],
-          },
-        },
-        paletteMetadata: { versions: {}, materials: {} },
-      });
-      setPathDeps({
-        getHashParamsforSelections: () => ({ head: "human_head" }),
-      });
-      const meta = {
-        replace_in_path: {
-          head: { human: "humanoid" },
-        },
-      };
-      expect(replaceInPath("base/${head}/tail", {}, meta)).to.equal(
-        "base/humanoid/tail",
-      );
+      expect(
+        replaceInPath(
+          defaultCatalog,
+          "base/${head}/tail",
+          templateSelections,
+          meta,
+        ),
+      ).to.equal("base/humanoid/tail");
     });
 
     it("calls debugLog when a placeholder has no replacement", () => {
+      seedTemplateCatalog();
       const debugLog = sinon.stub();
       setPathDeps({
-        getHashParamsforSelections: () => ({ head: "human_head" }),
         debugLog,
       });
       const meta = {
@@ -138,92 +127,98 @@ describe("state/path.ts", () => {
           head: {},
         },
       };
-      replaceInPath("base/${head}/tail", {}, meta);
+      replaceInPath(
+        defaultCatalog,
+        "base/${head}/tail",
+        templateSelections,
+        meta,
+      );
       expect(debugLog.calledOnce).to.be.true;
       expect(debugLog.firstCall.args[0]).to.include("head");
     });
 
     it("resolves multiple placeholders in one path", () => {
-      setPathDeps({
-        getHashParamsforSelections: () => ({
-          head: "human_head",
-          body: "shirt_red",
-        }),
-      });
+      seedTemplateCatalog();
       const meta = {
         replace_in_path: {
           head: { human: "h1" },
           body: { shirt: "s1" },
         },
       };
-      expect(replaceInPath("pre/${head}/mid/${body}/tail", {}, meta)).to.equal(
-        "pre/h1/mid/s1/tail",
-      );
+      expect(
+        replaceInPath(
+          defaultCatalog,
+          "pre/${head}/mid/${body}/tail",
+          templateSelections,
+          meta,
+        ),
+      ).to.equal("pre/h1/mid/s1/tail");
     });
 
     it("ignores extra hash keys that do not appear in the path", () => {
-      setPathDeps({
-        getHashParamsforSelections: () => ({
-          head: "human_head",
-          body: "shirt_red",
-        }),
-      });
+      seedTemplateCatalog();
       const meta = {
         replace_in_path: {
           head: { human: "humanoid" },
         },
       };
-      expect(replaceInPath("base/${head}/tail", {}, meta)).to.equal(
-        "base/humanoid/tail",
-      );
+      expect(
+        replaceInPath(
+          defaultCatalog,
+          "base/${head}/tail",
+          templateSelections,
+          meta,
+        ),
+      ).to.equal("base/humanoid/tail");
     });
 
-    it("passes an empty object to getHashParamsforSelections when selections is null or undefined", () => {
-      const getHashParamsforSelections = sinon.stub().returns({
-        head: "human_head",
-      });
-      setPathDeps({ getHashParamsforSelections });
+    it("treats null or undefined selections as empty", () => {
+      seedTemplateCatalog();
       const meta = {
         replace_in_path: {
           head: { human: "x" },
         },
       };
-      replaceInPath("p/${head}/q", null, meta);
-      expect(getHashParamsforSelections.firstCall.args[0]).to.deep.equal({});
-      getHashParamsforSelections.resetHistory();
-      replaceInPath("p/${head}/q", undefined, meta);
-      expect(getHashParamsforSelections.firstCall.args[0]).to.deep.equal({});
+      expect(replaceInPath(defaultCatalog, "p/${head}/q", null, meta)).to.equal(
+        "p/${head}/q",
+      );
+      expect(
+        replaceInPath(defaultCatalog, "p/${head}/q", undefined, meta),
+      ).to.equal("p/${head}/q");
     });
 
     it("leaves placeholders unchanged when the hash omits that key", () => {
-      setPathDeps({
-        getHashParamsforSelections: () => ({}),
-      });
+      seedTemplateCatalog();
       const meta = {
         replace_in_path: {
           head: { human: "humanoid" },
         },
       };
-      expect(replaceInPath("base/${head}/tail", {}, meta)).to.equal(
-        "base/${head}/tail",
-      );
+      expect(
+        replaceInPath(defaultCatalog, "base/${head}/tail", {}, meta),
+      ).to.equal("base/${head}/tail");
     });
 
     it("throws when meta.replace_in_path is missing", () => {
-      setPathDeps({
-        getHashParamsforSelections: () => ({ head: "human_head" }),
-      });
-      expect(() => replaceInPath("base/${head}/tail", {}, {})).to.throw();
+      seedTemplateCatalog();
+      expect(() =>
+        replaceInPath(
+          defaultCatalog,
+          "base/${head}/tail",
+          templateSelections,
+          {},
+        ),
+      ).to.throw();
     });
 
     it("invokes es6DynamicTemplate with the path and replacement map", () => {
+      seedTemplateCatalog();
       const es6Spy = sinon
         .stub()
         .callsFake((path, replacements) =>
           es6DynamicTemplate(path, replacements),
         );
       setPathDeps({
-        getHashParamsforSelections: () => ({ head: "human_head" }),
         es6DynamicTemplate: es6Spy,
       });
       const meta = {
@@ -232,19 +227,22 @@ describe("state/path.ts", () => {
         },
       };
       const path = "base/${head}/tail";
-      expect(replaceInPath(path, {}, meta)).to.equal("base/humanoid/tail");
+      expect(
+        replaceInPath(defaultCatalog, path, templateSelections, meta),
+      ).to.equal("base/humanoid/tail");
       expect(es6Spy.calledOnce).to.be.true;
       expect(es6Spy.firstCall.args[0]).to.equal(path);
-      expect(es6Spy.firstCall.args[1]).to.deep.equal({ head: "humanoid" });
+      expect(es6Spy.firstCall.args[1]).to.include({ head: "humanoid" });
     });
   });
 
   describe("getSpritePath", () => {
     it("forwards the LoadError when item metadata is missing", () => {
-      setPathDeps({
-        getItemMetadata: () => err({ kind: "not-found", id: "missing_id" }),
-      });
+      const catalog = {
+        getItemMerged: () => err({ kind: "not-found", id: "missing_id" }),
+      };
       const r = getSpritePath(
+        catalog,
         "missing_id",
         "v",
         null,
@@ -260,7 +258,17 @@ describe("state/path.ts", () => {
 
     it("returns a missing-layer error when the requested layer is absent", () => {
       const meta = { layers: {} };
-      const r = getSpritePath("id", "v", null, "male", "walk", 2, {}, meta);
+      const r = getSpritePath(
+        defaultCatalog,
+        "id",
+        "v",
+        null,
+        "male",
+        "walk",
+        2,
+        {},
+        meta,
+      );
       expect(r.isErr()).to.be.true;
       if (r.isErr()) {
         expect(r.error).to.deep.equal({ kind: "missing-layer", layerNum: 2 });
@@ -273,7 +281,17 @@ describe("state/path.ts", () => {
           layer_1: { female: "path/" },
         },
       };
-      const r = getSpritePath("id", "v", null, "male", "walk", 1, {}, meta);
+      const r = getSpritePath(
+        defaultCatalog,
+        "id",
+        "v",
+        null,
+        "male",
+        "walk",
+        1,
+        {},
+        meta,
+      );
       expect(r.isErr()).to.be.true;
       if (r.isErr()) {
         expect(r.error).to.deep.equal({
@@ -297,6 +315,7 @@ describe("state/path.ts", () => {
       });
       expect(
         getSpritePath(
+          defaultCatalog,
           "item",
           "light brown",
           null,
@@ -325,6 +344,7 @@ describe("state/path.ts", () => {
       });
       expect(
         getSpritePath(
+          defaultCatalog,
           "item",
           "v",
           null,
@@ -351,6 +371,7 @@ describe("state/path.ts", () => {
       });
       expect(
         getSpritePath(
+          defaultCatalog,
           "shirt_blue_red",
           null,
           null,
@@ -376,6 +397,7 @@ describe("state/path.ts", () => {
       });
       expect(
         getSpritePath(
+          defaultCatalog,
           "id",
           "v",
           true,
@@ -389,6 +411,7 @@ describe("state/path.ts", () => {
     });
 
     it("runs replaceInPath when the layer path contains ${}", () => {
+      seedTemplateCatalog();
       const meta = {
         layers: {
           layer_1: {
@@ -400,19 +423,19 @@ describe("state/path.ts", () => {
         },
       };
       setPathDeps({
-        getHashParamsforSelections: () => ({ head: "human_head" }),
         variantToFilename: (v) => v,
         animations: [{ value: "idle", label: "Idle" }],
       });
       expect(
         getSpritePath(
+          defaultCatalog,
           "item",
           "v",
           null,
           "male",
           "idle",
           1,
-          {},
+          templateSelections,
           meta,
         )._unsafeUnwrap(),
       ).to.equal("spritesheets/prefix/humanoid/idle/v.png");

--- a/tests/utils/credits_spec.js
+++ b/tests/utils/credits_spec.js
@@ -5,7 +5,10 @@ import {
   creditsToCsv,
   creditsToTxt,
 } from "../../sources/utils/credits.ts";
-import { resetCatalogForTests } from "../../sources/state/catalog.ts";
+import {
+  defaultCatalog,
+  resetCatalogForTests,
+} from "../../sources/state/catalog.ts";
 import {
   restoreAppCatalogAfterTest,
   seedBrowserCatalog,
@@ -28,7 +31,7 @@ describe("utils/credits.ts", () => {
   describe("getAllCredits", () => {
     it("returns an empty array when selections is empty", () => {
       seedBrowserCatalog({});
-      expect(getAllCredits({}, "male")).to.deep.equal([]);
+      expect(getAllCredits(defaultCatalog, {}, "male")).to.deep.equal([]);
     });
 
     it("skips items with no metadata or no credits", () => {
@@ -39,7 +42,11 @@ describe("utils/credits.ts", () => {
         },
       });
       expect(
-        getAllCredits({ g: { itemId: "noCredits", variant: null } }, "male"),
+        getAllCredits(
+          defaultCatalog,
+          { g: { itemId: "noCredits", variant: null } },
+          "male",
+        ),
       ).to.deep.equal([]);
     });
 
@@ -64,6 +71,7 @@ describe("utils/credits.ts", () => {
       state.selectedAnimation = "walk";
 
       const result = getAllCredits(
+        defaultCatalog,
         { slot: { itemId: "item1", variant: null } },
         "male",
       );
@@ -96,6 +104,7 @@ describe("utils/credits.ts", () => {
       state.selectedAnimation = "walk";
 
       const result = getAllCredits(
+        defaultCatalog,
         { slot: { itemId: "item1", variant: "light brown" } },
         "male",
       );
@@ -124,6 +133,7 @@ describe("utils/credits.ts", () => {
       state.selectedAnimation = "run";
 
       const result = getAllCredits(
+        defaultCatalog,
         { slot: { itemId: "item1", variant: null } },
         "male",
       );
@@ -151,6 +161,7 @@ describe("utils/credits.ts", () => {
       state.selectedAnimation = undefined;
 
       const result = getAllCredits(
+        defaultCatalog,
         { slot: { itemId: "item1", variant: null } },
         "male",
       );
@@ -178,6 +189,7 @@ describe("utils/credits.ts", () => {
       state.selectedAnimation = "walk";
 
       const result = getAllCredits(
+        defaultCatalog,
         { slot: { itemId: "item1", variant: null } },
         "male",
       );
@@ -212,6 +224,7 @@ describe("utils/credits.ts", () => {
       state.selectedAnimation = "walk";
 
       const result = getAllCredits(
+        defaultCatalog,
         { slot: { itemId: "item1", variant: null } },
         "male",
       );

--- a/tests/utils/zip-helpers_spec.js
+++ b/tests/utils/zip-helpers_spec.js
@@ -22,6 +22,7 @@ import {
   zipGenerateBlobWithProfiler,
 } from "../../sources/utils/zip-helpers.ts";
 import { DIRECTIONS } from "../../sources/state/constants.ts";
+import { defaultCatalog } from "../../sources/state/catalog.ts";
 
 function createCanvas(width, height) {
   const canvas = document.createElement("canvas");
@@ -637,7 +638,13 @@ describe("utils/zip-helpers.ts", () => {
         };
         const layerList = [];
 
-        addCharacterJsonAndCredits(zip, creditsFolder, state, layerList);
+        addCharacterJsonAndCredits(
+          defaultCatalog,
+          zip,
+          creditsFolder,
+          state,
+          layerList,
+        );
 
         expect(rootWrites).to.have.length(1);
         expect(rootWrites[0].name).to.equal("character.json");


### PR DESCRIPTION
Another day another bit.

There are many catalog specific subsets in these types. Once this refactor is over, I may change the APIs to stop using a broad catalog object, and pass the actual values directly where it makes sense.