### PR TITLE
feat: Migrate palette and recoloring to catalog DI

### DIFF
--- a/sources/canvas/palette-recolor.ts
+++ b/sources/canvas/palette-recolor.ts
@@ -9,7 +9,6 @@ import {
 } from "./webgl-palette-recolor.ts";
 import { debugLog, debugWarn } from "../utils/debug.ts";
 import { get2DContext } from "./canvas-utils.ts";
-import { getItemLite } from "../state/catalog.ts";
 import type { CatalogReader, ItemMerged } from "../state/catalog.ts";
 import { state } from "../state/state.ts";
 import { getLayersToLoad } from "../state/meta.ts";
@@ -274,6 +273,7 @@ const recolorCache = new Map<
  * same (spritePath, recolors) skip the entire recolor pipeline.
  */
 export async function getImageToDraw(
+  catalog: CatalogReader,
   img: HTMLImageElement | HTMLCanvasElement,
   itemId: string,
   recolors: Record<string, string> | null | undefined,
@@ -282,8 +282,8 @@ export async function getImageToDraw(
   if (!recolors) {
     return img; // No recolor specified, return original image
   }
-  const meta = getItemLite(itemId).unwrapOr(null);
-  const paletteConfig = getPalettesFromMeta(meta).unwrapOr(null);
+  const meta = catalog.getItemLite(itemId).unwrapOr(null);
+  const paletteConfig = getPalettesFromMeta(catalog, meta).unwrapOr(null);
   if (!paletteConfig) {
     return img; // Item doesn't use palette recoloring
   }
@@ -301,7 +301,7 @@ export async function getImageToDraw(
     }
   }
 
-  const promise = recolorWithPalette(img, recolors, paletteConfig);
+  const promise = recolorWithPalette(catalog, img, recolors, paletteConfig);
 
   if (cacheKey) {
     recolorCache.set(cacheKey, promise);
@@ -339,6 +339,7 @@ export function clearRecolorCache(): void {
  * Automatically loads the palette on first use (lazy loading).
  */
 export async function recolorWithPalette(
+  catalog: CatalogReader,
   sourceImage: HTMLImageElement | HTMLCanvasElement,
   targetColors: Record<string, string>,
   sourcePalettes: Record<string, PaletteForItem>,
@@ -350,6 +351,7 @@ export async function recolorWithPalette(
     const targetColor = targetColors[typeName];
     if (!targetColor || targetColor === "source") continue;
     const targetPalette = getTargetPalette(
+      catalog,
       palette.material,
       targetColor,
     ).unwrapOr(null);
@@ -455,6 +457,7 @@ export async function drawRecolorPreview(
 
     if (img) {
       const imageToDraw = await getImageToDraw(
+        catalog,
         img,
         itemId,
         selectedColors,

--- a/sources/canvas/renderer.ts
+++ b/sources/canvas/renderer.ts
@@ -268,7 +268,7 @@ async function runRenderCharacter(
       }
 
       // Get Multiple Recolors If Available
-      const recolors = getMultiRecolors(itemId, selections);
+      const recolors = getMultiRecolors(defaultCatalog, itemId, selections);
 
       // Process all layers for this item
       for (let layerNum = 1; layerNum < 10; layerNum++) {
@@ -472,6 +472,7 @@ async function runRenderCharacter(
     for (const { item, img, success } of loadedItems) {
       if (success && img) {
         const imageToDraw = await getImageToDraw(
+          defaultCatalog,
           img,
           item.itemId,
           item.recolors,
@@ -546,6 +547,7 @@ async function runRenderCharacter(
         for (const { item: areaItem, img, success } of loadedCustomImages) {
           if (success && img) {
             const imageToUse = await getImageToDraw(
+              defaultCatalog,
               img,
               areaItem.itemId,
               areaItem.recolors,
@@ -758,6 +760,7 @@ export async function renderSingleItem(
         for (const { item: sprite, img, success } of loadedSprites) {
           if (success && img) {
             const imageToDraw = await getImageToDraw(
+              defaultCatalog,
               img,
               itemId,
               recolors,
@@ -867,6 +870,7 @@ export async function renderSingleItem(
         for (const { item: sprite, img, success } of loadedImages) {
           if (success && img) {
             const imageToDraw = await getImageToDraw(
+              defaultCatalog,
               img,
               itemId,
               sprite.recolors,
@@ -1012,6 +1016,7 @@ export async function renderSingleItemAnimation(
       for (const { item: sprite, img, success } of loadedImages) {
         if (success && img) {
           const imageToDraw = await getImageToDraw(
+            defaultCatalog,
             img,
             itemId,
             sprite.recolors,

--- a/sources/components/tree/ItemWithRecolors.ts
+++ b/sources/components/tree/ItemWithRecolors.ts
@@ -62,7 +62,11 @@ export const ItemWithRecolors: m.Component<
     const paletteReady = catalog.isPaletteReady();
 
     // Build palette/color options for all recolor fields
-    const [paletteOptions, selectedColors] = getPaletteOptions(itemId, meta);
+    const [paletteOptions, selectedColors] = getPaletteOptions(
+      catalog,
+      itemId,
+      meta,
+    );
 
     // Check Selection Status
     let paletteModal = null;

--- a/sources/state/hash.ts
+++ b/sources/state/hash.ts
@@ -193,6 +193,7 @@ export function buildNewSelection(
     let recolorLabel: string | null | undefined = newSelection.recolor;
     if (recolorLabel) {
       const [, ver, recolor] = parseRecolorKey(
+        defaultCatalog,
         newSelection.recolor ?? null,
         subMeta,
       );

--- a/sources/state/palettes.ts
+++ b/sources/state/palettes.ts
@@ -55,11 +55,7 @@ export function fixMissingRecolor(
   // Get material from palette metadata
   const materialMeta =
     paletteMetaOrNull(catalog)?.materials?.[palette.material];
-  const [, , parsedRecolor] = parseRecolorKey(
-    catalog,
-    recolor,
-    materialMeta,
-  );
+  const [, , parsedRecolor] = parseRecolorKey(catalog, recolor, materialMeta);
 
   // See if recolor is non-standard for the current asset
   for (const variant of palette.variants ?? []) {

--- a/sources/state/palettes.ts
+++ b/sources/state/palettes.ts
@@ -2,8 +2,7 @@
 import { ok, err, type Result } from "neverthrow";
 import { state, getSelectionGroup, type Selections } from "./state.ts";
 import {
-  getItemLite,
-  getPaletteMetadata,
+  type CatalogReader,
   type ItemLite,
   type LoadError,
   type PaletteMaterialMeta,
@@ -12,11 +11,11 @@ import {
 } from "./catalog.ts";
 
 /** Local helpers — collapse `Result<T, _>` into `T | null` for ergonomics. */
-function liteOrNull(itemId: string): ItemLite | null {
-  return getItemLite(itemId).unwrapOr(null);
+function liteOrNull(catalog: CatalogReader, itemId: string): ItemLite | null {
+  return catalog.getItemLite(itemId).unwrapOr(null);
 }
-function paletteMetaOrNull(): PaletteMetadata | null {
-  return getPaletteMetadata().unwrapOr(null);
+function paletteMetaOrNull(catalog: CatalogReader): PaletteMetadata | null {
+  return catalog.getPaletteMetadata().unwrapOr(null);
 }
 
 /**
@@ -36,11 +35,12 @@ export type RecolorFixError =
  * exists, distinguishing load failure from domain "no match" outcomes.
  */
 export function fixMissingRecolor(
+  catalog: CatalogReader,
   itemId: string,
   recolor: string,
   typeName: string | null = null,
 ): Result<string, RecolorFixError> {
-  const metaResult = getItemLite(itemId);
+  const metaResult = catalog.getItemLite(itemId);
   if (metaResult.isErr()) return err(metaResult.error);
   const meta = metaResult.value;
 
@@ -53,8 +53,13 @@ export function fixMissingRecolor(
   }
 
   // Get material from palette metadata
-  const materialMeta = paletteMetaOrNull()?.materials?.[palette.material];
-  const [, , parsedRecolor] = parseRecolorKey(recolor, materialMeta);
+  const materialMeta =
+    paletteMetaOrNull(catalog)?.materials?.[palette.material];
+  const [, , parsedRecolor] = parseRecolorKey(
+    catalog,
+    recolor,
+    materialMeta,
+  );
 
   // See if recolor is non-standard for the current asset
   for (const variant of palette.variants ?? []) {
@@ -73,10 +78,11 @@ export function fixMissingRecolor(
  * `type_name`, valued by recolor variant. Returns null when no recolors apply.
  */
 export function getMultiRecolors(
+  catalog: CatalogReader,
   itemId: string,
   selections: Selections,
 ): Record<string, string> | null {
-  const meta = liteOrNull(itemId);
+  const meta = liteOrNull(catalog, itemId);
   if (!meta) return null;
   const types: string[] = [meta.type_name];
   for (const recolor of meta.recolors) {
@@ -87,7 +93,7 @@ export function getMultiRecolors(
 
   const recolors: Record<string, string> = {};
   for (const [, selection] of Object.entries(selections)) {
-    const subMeta = liteOrNull(selection.itemId);
+    const subMeta = liteOrNull(catalog, selection.itemId);
     const typeName =
       (selection.subId !== null && selection.subId !== undefined
         ? subMeta?.recolors?.[selection.subId]?.type_name
@@ -103,6 +109,7 @@ export function getMultiRecolors(
       continue;
 
     const verifiedRecolor = fixMissingRecolor(
+      catalog,
       itemId,
       selection.recolor ?? "",
       !selection.subId ? null : typeName,
@@ -118,7 +125,7 @@ export function getMultiRecolors(
 
   // If body color, force match body color
   if (meta.matchBodyColor && state.matchBodyColorEnabled) {
-    const bodyColor = getBodyColor(itemId, selections).unwrapOr(null);
+    const bodyColor = getBodyColor(catalog, itemId, selections).unwrapOr(null);
     if (bodyColor) recolors[meta.type_name] = bodyColor;
   }
 
@@ -133,17 +140,18 @@ export type BodyColorError =
 
 /** Find body color from selections when match body color is enabled on an item. */
 export function getBodyColor(
+  catalog: CatalogReader,
   itemId: string,
   selections: Selections,
 ): Result<string, BodyColorError> {
-  const metaResult = getItemLite(itemId);
+  const metaResult = catalog.getItemLite(itemId);
   if (metaResult.isErr()) return err(metaResult.error);
   const meta = metaResult.value;
 
   if (!meta.matchBodyColor) return err({ kind: "match-body-color-disabled" });
 
   for (const [, selection] of Object.entries(selections)) {
-    const subMeta = liteOrNull(selection.itemId);
+    const subMeta = liteOrNull(catalog, selection.itemId);
     if (subMeta && subMeta.matchBodyColor && selection.recolor) {
       return ok(selection.recolor);
     }
@@ -166,11 +174,12 @@ export type PaletteLookupError =
  * colors]`, err when the material is unknown (also logs to console).
  */
 export function getBasePalette(
+  catalog: CatalogReader,
   material: string,
   base: string | null = null,
   source: string[] | null = null,
 ): Result<[string, string, string[]], PaletteLookupError> {
-  const materialMeta = paletteMetaOrNull()?.materials?.[material];
+  const materialMeta = paletteMetaOrNull(catalog)?.materials?.[material];
   if (!materialMeta) {
     console.error(`Palettes for ${material} not found`);
     return err({ kind: "material-not-found", material });
@@ -191,17 +200,22 @@ export function getBasePalette(
 
 /** Resolve the target color array for a recolor key. */
 export function getTargetPalette(
+  catalog: CatalogReader,
   material: string,
   targetColor: string,
 ): Result<string[], PaletteLookupError> {
-  const paletteMeta = paletteMetaOrNull();
+  const paletteMeta = paletteMetaOrNull(catalog);
   let materialMeta = paletteMeta?.materials?.[material];
   if (!materialMeta) {
     console.error(`Palettes for ${material} not found`);
     return err({ kind: "material-not-found", material });
   }
 
-  const [newMat, version, recolor] = parseRecolorKey(targetColor, materialMeta);
+  const [newMat, version, recolor] = parseRecolorKey(
+    catalog,
+    targetColor,
+    materialMeta,
+  );
   if (newMat) {
     const newMaterialMeta = paletteMeta?.materials?.[newMat];
     if (newMaterialMeta) {
@@ -233,6 +247,7 @@ export type PalettesFromMetaError = { kind: "no-recolors-on-item" };
 
 /** Build the palette configuration from an item's meta, keyed by `type_name`. */
 export function getPalettesFromMeta(
+  catalog: CatalogReader,
   meta: ItemLite | null,
 ): Result<Record<string, PaletteForItem>, PalettesFromMetaError> {
   if (!meta || !meta.recolors) return err({ kind: "no-recolors-on-item" });
@@ -242,6 +257,7 @@ export function getPalettesFromMeta(
     // `getBasePalette` errs when the material is unknown; preserve the legacy
     // crash-on-null destructure rather than silently masking that bug.
     const [version, source, colors] = getBasePalette(
+      catalog,
       palette.material,
       palette.base ?? null,
       palette.source ?? null,
@@ -274,12 +290,13 @@ export const CUSTOM_VERSION: string = "custom";
 
 /** Palette options + currently-selected colors for the item's selection group. */
 export function getPaletteOptions(
+  catalog: CatalogReader,
   itemId: string,
   meta: ItemLite,
 ): [PaletteOption[], Record<string, string>] {
   const selectionGroup = getSelectionGroup(itemId);
   const paletteOptions: PaletteOption[] = [];
-  const selectedColors = getMultiRecolors(itemId, state.selections);
+  const selectedColors = getMultiRecolors(catalog, itemId, state.selections);
 
   if (meta.recolors && meta.recolors.length > 0) {
     meta.recolors.forEach((color, idx) => {
@@ -289,6 +306,7 @@ export function getPaletteOptions(
       const selectedColor = selectedColors?.[subGroup] ?? null;
 
       const [material, version, recolor] = parseRecolorKey(
+        catalog,
         selectedColor,
         color,
       );
@@ -301,9 +319,11 @@ export function getPaletteOptions(
       if (selectedColor === CUSTOM_KEY || (!selectedColor && color.source)) {
         palette = color.source ?? null;
       } else if (material !== undefined) {
-        palette = getTargetPalette(material, `${version}.${recolor}`).unwrapOr(
-          null,
-        );
+        palette = getTargetPalette(
+          catalog,
+          material,
+          `${version}.${recolor}`,
+        ).unwrapOr(null);
       }
 
       paletteOptions.push({
@@ -330,6 +350,7 @@ export function getPaletteOptions(
  * those segments are absent.
  */
 export function parseRecolorKey(
+  catalog: CatalogReader,
   recolorKey: string | null,
   palette: PaletteRecolor | PaletteMaterialMeta | undefined,
 ): [string | undefined, string | undefined, string] {
@@ -343,7 +364,7 @@ export function parseRecolorKey(
   // Material (e.g. body, metal, cloth)
   if (!material) {
     // Maybe `version` is actually the material name
-    if (version && paletteMetaOrNull()?.materials?.[version]) {
+    if (version && paletteMetaOrNull(catalog)?.materials?.[version]) {
       material = version;
       version = undefined;
     } else {

--- a/sources/state/zip.ts
+++ b/sources/state/zip.ts
@@ -270,7 +270,11 @@ export const exportSplitItemSheets = async (
       ).unwrapOr([]);
 
       // Get Multiple Recolors If Available
-      const recolors = getMultiRecolors(itemId, state.selections);
+      const recolors = getMultiRecolors(
+        defaultCatalog,
+        itemId,
+        state.selections,
+      );
 
       // Render each layer of the item separately
       for (const layer of itemLayers) {
@@ -437,7 +441,11 @@ export const exportSplitItemAnimations = async (
         }
 
         // Get Multiple Recolors If Available
-        const recolors = getMultiRecolors(itemId, state.selections);
+        const recolors = getMultiRecolors(
+          defaultCatalog,
+          itemId,
+          state.selections,
+        );
 
         const itemLayers = getSortedLayersWithCustomFallback(
           defaultCatalog,
@@ -516,6 +524,7 @@ export const exportSplitItemAnimations = async (
             "render_composite_customItemSprite",
             async () => {
               imgCanvas = await getImageToDrawFn(
+                defaultCatalog,
                 img!,
                 layer.itemId,
                 layer.recolors,

--- a/tests/browser-catalog-fixture.js
+++ b/tests/browser-catalog-fixture.js
@@ -1,4 +1,5 @@
 import {
+  defaultCatalog,
   loadCatalogFromFixtures,
   resetCatalogForTests,
 } from "../sources/state/catalog.ts";
@@ -38,8 +39,13 @@ function mergedItemMapFromLoadedChunks(loaded) {
  * @param {{ aliasMetadata?: object, categoryTree?: object, paletteMetadata?: object }} [extras]
  */
 export function seedBrowserCatalog(itemMetadata, extras = {}) {
+  seedCatalog(defaultCatalog, itemMetadata, extras);
+}
+
+/** Seed a specific catalog instance from a merged item map. */
+export function seedCatalog(catalog, itemMetadata, extras = {}) {
   const byTypeName = buildItemsByTypeNameLite(itemMetadata);
-  loadCatalogFromFixtures({
+  catalog.loadCatalogFromFixtures({
     itemMetadata,
     aliasMetadata: extras.aliasMetadata ?? {},
     categoryTree: extras.categoryTree ?? emptyTree,

--- a/tests/canvas/palette-recolor-cache_spec.js
+++ b/tests/canvas/palette-recolor-cache_spec.js
@@ -15,6 +15,7 @@ import {
   getImageToDraw,
   clearRecolorCache,
 } from "../../sources/canvas/palette-recolor.ts";
+import { defaultCatalog } from "../../sources/state/catalog.ts";
 
 // Real item id from the dataset with a single recolor region.
 // `body` has type_name="body", recolors=[{material: "body"}].
@@ -40,8 +41,20 @@ describe("canvas/palette-recolor.ts recolor cache", () => {
     const recolors = { body: "olive" };
     const path = "spritesheets/body/bodies/male/walk.png";
 
-    const first = await getImageToDraw(img, RECOLOR_ITEM_ID, recolors, path);
-    const second = await getImageToDraw(img, RECOLOR_ITEM_ID, recolors, path);
+    const first = await getImageToDraw(
+      defaultCatalog,
+      img,
+      RECOLOR_ITEM_ID,
+      recolors,
+      path,
+    );
+    const second = await getImageToDraw(
+      defaultCatalog,
+      img,
+      RECOLOR_ITEM_ID,
+      recolors,
+      path,
+    );
 
     expect(first).to.equal(second);
   });
@@ -51,12 +64,14 @@ describe("canvas/palette-recolor.ts recolor cache", () => {
     const path = "spritesheets/body/bodies/male/walk.png";
 
     const olive = await getImageToDraw(
+      defaultCatalog,
       img,
       RECOLOR_ITEM_ID,
       { body: "olive" },
       path,
     );
     const bronze = await getImageToDraw(
+      defaultCatalog,
       img,
       RECOLOR_ITEM_ID,
       { body: "bronze" },
@@ -71,12 +86,14 @@ describe("canvas/palette-recolor.ts recolor cache", () => {
     const recolors = { body: "olive" };
 
     const a = await getImageToDraw(
+      defaultCatalog,
       img,
       RECOLOR_ITEM_ID,
       recolors,
       "spritesheets/body/bodies/male/walk.png",
     );
     const b = await getImageToDraw(
+      defaultCatalog,
       img,
       RECOLOR_ITEM_ID,
       recolors,
@@ -90,8 +107,20 @@ describe("canvas/palette-recolor.ts recolor cache", () => {
     const img = solidColorCanvas(255, 0, 0);
     const recolors = { body: "olive" };
 
-    const first = await getImageToDraw(img, RECOLOR_ITEM_ID, recolors, null);
-    const second = await getImageToDraw(img, RECOLOR_ITEM_ID, recolors, null);
+    const first = await getImageToDraw(
+      defaultCatalog,
+      img,
+      RECOLOR_ITEM_ID,
+      recolors,
+      null,
+    );
+    const second = await getImageToDraw(
+      defaultCatalog,
+      img,
+      RECOLOR_ITEM_ID,
+      recolors,
+      null,
+    );
 
     expect(first).to.not.equal(second);
   });
@@ -100,7 +129,13 @@ describe("canvas/palette-recolor.ts recolor cache", () => {
     const img = solidColorCanvas(255, 0, 0);
     const path = "spritesheets/body/bodies/male/walk.png";
 
-    const result = await getImageToDraw(img, RECOLOR_ITEM_ID, null, path);
+    const result = await getImageToDraw(
+      defaultCatalog,
+      img,
+      RECOLOR_ITEM_ID,
+      null,
+      path,
+    );
 
     expect(result).to.equal(img);
   });
@@ -110,9 +145,21 @@ describe("canvas/palette-recolor.ts recolor cache", () => {
     const recolors = { body: "olive" };
     const path = "spritesheets/body/bodies/male/walk.png";
 
-    const first = await getImageToDraw(img, RECOLOR_ITEM_ID, recolors, path);
+    const first = await getImageToDraw(
+      defaultCatalog,
+      img,
+      RECOLOR_ITEM_ID,
+      recolors,
+      path,
+    );
     clearRecolorCache();
-    const second = await getImageToDraw(img, RECOLOR_ITEM_ID, recolors, path);
+    const second = await getImageToDraw(
+      defaultCatalog,
+      img,
+      RECOLOR_ITEM_ID,
+      recolors,
+      path,
+    );
 
     expect(first).to.not.equal(second);
   });
@@ -123,9 +170,9 @@ describe("canvas/palette-recolor.ts recolor cache", () => {
     const path = "spritesheets/body/bodies/male/walk.png";
 
     const [a, b, c] = await Promise.all([
-      getImageToDraw(img, RECOLOR_ITEM_ID, recolors, path),
-      getImageToDraw(img, RECOLOR_ITEM_ID, recolors, path),
-      getImageToDraw(img, RECOLOR_ITEM_ID, recolors, path),
+      getImageToDraw(defaultCatalog, img, RECOLOR_ITEM_ID, recolors, path),
+      getImageToDraw(defaultCatalog, img, RECOLOR_ITEM_ID, recolors, path),
+      getImageToDraw(defaultCatalog, img, RECOLOR_ITEM_ID, recolors, path),
     ]);
 
     expect(a).to.equal(b);

--- a/tests/canvas/palette-recolor-merge_spec.js
+++ b/tests/canvas/palette-recolor-merge_spec.js
@@ -14,7 +14,10 @@ import {
   setPaletteRecolorMode,
   getPaletteRecolorConfig,
 } from "../../sources/canvas/palette-recolor.ts";
-import { getPaletteMetadata } from "../../sources/state/catalog.ts";
+import {
+  defaultCatalog,
+  getPaletteMetadata,
+} from "../../sources/state/catalog.ts";
 import {
   solidCanvas,
   splitCanvas,
@@ -134,6 +137,7 @@ describe("canvas/palette-recolor.ts single-pass merge (CPU path)", () => {
     const img = solidCanvas(srcRgb.r, srcRgb.g, srcRgb.b);
 
     const out = await recolorWithPalette(
+      defaultCatalog,
       img,
       {},
       {

--- a/tests/state/palettes_spec.js
+++ b/tests/state/palettes_spec.js
@@ -1,9 +1,6 @@
 import { expect } from "chai";
 import { describe, it, beforeEach, afterEach } from "mocha-globals";
-import {
-  createCatalog,
-  defaultCatalog,
-} from "../../sources/state/catalog.ts";
+import { createCatalog, defaultCatalog } from "../../sources/state/catalog.ts";
 import { seedCatalog } from "../browser-catalog-fixture.js";
 import { state } from "../../sources/state/state.ts";
 import {

--- a/tests/state/palettes_spec.js
+++ b/tests/state/palettes_spec.js
@@ -1,11 +1,10 @@
 import { expect } from "chai";
 import { describe, it, beforeEach, afterEach } from "mocha-globals";
-import { resetCatalogForTests } from "../../sources/state/catalog.ts";
-import { getItemLite } from "../../sources/state/catalog.ts";
 import {
-  restoreAppCatalogAfterTest,
-  seedBrowserCatalog,
-} from "../browser-catalog-fixture.js";
+  createCatalog,
+  defaultCatalog,
+} from "../../sources/state/catalog.ts";
+import { seedCatalog } from "../browser-catalog-fixture.js";
 import { state } from "../../sources/state/state.ts";
 import {
   getMultiRecolors,
@@ -15,12 +14,13 @@ import {
 describe("state/palettes.ts", () => {
   let previousSelections;
   let previousMatchBodyColorEnabled;
+  let catalog;
 
   beforeEach(() => {
     previousSelections = state.selections;
     previousMatchBodyColorEnabled = state.matchBodyColorEnabled;
     state.matchBodyColorEnabled = true;
-    resetCatalogForTests();
+    catalog = createCatalog();
 
     const paletteMetadata = {
       materials: {
@@ -273,14 +273,22 @@ describe("state/palettes.ts", () => {
       },
     };
 
-    seedBrowserCatalog(testItemMetadata, { paletteMetadata });
+    seedCatalog(catalog, testItemMetadata, { paletteMetadata });
     state.selections = {};
   });
 
-  afterEach(async () => {
+  afterEach(() => {
     state.selections = previousSelections;
     state.matchBodyColorEnabled = previousMatchBodyColorEnabled;
-    await restoreAppCatalogAfterTest();
+  });
+
+  it("uses the provided catalog instead of the default singleton", () => {
+    const itemId = "hair_long_tied_test";
+    const meta = catalog.getItemLite(itemId)._unsafeUnwrap();
+
+    expect(defaultCatalog.getItemLite(itemId).isErr()).to.equal(true);
+    const [paletteOptions] = getPaletteOptions(catalog, itemId, meta);
+    expect(paletteOptions).to.have.lengthOf(2);
   });
 
   it("falls back to a matching dotted recolor when the exact recolor is missing", () => {
@@ -292,6 +300,7 @@ describe("state/palettes.ts", () => {
     };
 
     const recolors = getMultiRecolors(
+      catalog,
       "torso_clothes_shortsleeve",
       state.selections,
     );
@@ -308,6 +317,7 @@ describe("state/palettes.ts", () => {
     };
 
     const recolors = getMultiRecolors(
+      catalog,
       "torso_clothes_shortsleeve",
       state.selections,
     );
@@ -324,8 +334,9 @@ describe("state/palettes.ts", () => {
     };
 
     const [paletteOptions, selectedColors] = getPaletteOptions(
+      catalog,
       "head_ears_elven",
-      getItemLite("head_ears_elven").unwrapOr(null),
+      catalog.getItemLite("head_ears_elven").unwrapOr(null),
     );
 
     expect(selectedColors).to.deep.equal({ ears: "bronze" });
@@ -341,8 +352,9 @@ describe("state/palettes.ts", () => {
 
   it("defaults source-backed recolors to source in getPaletteOptions", () => {
     const [paletteOptions, selectedColors] = getPaletteOptions(
+      catalog,
       "hair_long_tied_test",
-      getItemLite("hair_long_tied_test").unwrapOr(null),
+      catalog.getItemLite("hair_long_tied_test").unwrapOr(null),
     );
 
     expect(selectedColors).to.deep.equal({});
@@ -370,7 +382,11 @@ describe("state/palettes.ts", () => {
       },
     };
 
-    const recolors = getMultiRecolors("heads_human_male", state.selections);
+    const recolors = getMultiRecolors(
+      catalog,
+      "heads_human_male",
+      state.selections,
+    );
 
     expect(recolors).to.deep.equal({ head: "light", eyes: "green" });
   });
@@ -392,7 +408,11 @@ describe("state/palettes.ts", () => {
       },
     };
 
-    const recolors = getMultiRecolors("heads_human_male", state.selections);
+    const recolors = getMultiRecolors(
+      catalog,
+      "heads_human_male",
+      state.selections,
+    );
 
     expect(recolors).to.deep.equal({ head: "bronze", eyes: "lpcr.black" });
   });
@@ -415,7 +435,11 @@ describe("state/palettes.ts", () => {
       },
     };
 
-    const recolors = getMultiRecolors("heads_human_male", state.selections);
+    const recolors = getMultiRecolors(
+      catalog,
+      "heads_human_male",
+      state.selections,
+    );
 
     expect(recolors).to.deep.equal({ head: "light", eyes: "lpcr.black" });
   });
@@ -433,7 +457,11 @@ describe("state/palettes.ts", () => {
       },
     };
 
-    const recolors = getMultiRecolors("heads_human_male", state.selections);
+    const recolors = getMultiRecolors(
+      catalog,
+      "heads_human_male",
+      state.selections,
+    );
 
     expect(recolors).to.deep.equal({ head: "bronze" });
   });
@@ -446,7 +474,11 @@ describe("state/palettes.ts", () => {
       },
     };
 
-    const recolors = getMultiRecolors("shoulders_legion", state.selections);
+    const recolors = getMultiRecolors(
+      catalog,
+      "shoulders_legion",
+      state.selections,
+    );
 
     expect(recolors).to.deep.equal({ shoulders: "all.lpcr.red" });
   });
@@ -459,7 +491,11 @@ describe("state/palettes.ts", () => {
       },
     };
 
-    const recolors = getMultiRecolors("shoulders_legion", state.selections);
+    const recolors = getMultiRecolors(
+      catalog,
+      "shoulders_legion",
+      state.selections,
+    );
 
     expect(recolors).to.deep.equal({ shoulders: "brass" });
   });
@@ -480,7 +516,11 @@ describe("state/palettes.ts", () => {
       },
     };
 
-    const recolors = getMultiRecolors("shoulders_epaulets", state.selections);
+    const recolors = getMultiRecolors(
+      catalog,
+      "shoulders_epaulets",
+      state.selections,
+    );
 
     expect(recolors).to.equal(null);
   });


### PR DESCRIPTION
## Summary

  - Injects CatalogReader into palette lookup and recoloring APIs.
  - Removes implicit catalog singleton reads from state/palettes.ts and canvas/palette-recolor.ts.
  - Passes the injected catalog through ItemWithRecolors.
  - Uses defaultCatalog explicitly at the not-yet-migrated renderer and ZIP boundaries.
  - Updates palette/recolor tests and adds isolated catalog fixture support.