### PR TITLE
feat: Migrate catalog for renderer

### DIFF
--- a/scripts/zip/zip-export-profile-runner.js
+++ b/scripts/zip/zip-export-profile-runner.js
@@ -31,6 +31,7 @@ import {
   resetState,
 } from "../../sources/state/hash.js";
 import { state } from "../../sources/state/state.js";
+import { defaultCatalog } from "../../sources/state/catalog.ts";
 import { ZIP_PROFILE_DEFAULT_HASH } from "./zip-profile-default-hash.js";
 
 /** @type {readonly string[]} */
@@ -113,7 +114,7 @@ async function runProfiles(opts = {}) {
   ctx.fillStyle = "#445566";
   ctx.fillRect(0, 0, SHEET_WIDTH, SHEET_HEIGHT);
 
-  await renderCharacter(state.selections, state.bodyType);
+  await renderCharacter(defaultCatalog, state.selections, state.bodyType);
 
   if (run("splitAnimations")) {
     await exportSplitAnimations();

--- a/sources/canvas/renderer.ts
+++ b/sources/canvas/renderer.ts
@@ -25,12 +25,7 @@ import {
 } from "./preview-animation.ts";
 import { getSortedLayersByAnim } from "../state/meta.ts";
 import type { AnimationLayer } from "../state/meta.ts";
-import {
-  catalogReady,
-  defaultCatalog,
-  formatLoadError,
-  getItemMerged,
-} from "../state/catalog.ts";
+import { formatLoadError, type CatalogReader } from "../state/catalog.ts";
 import m from "mithril";
 import { debugWarn } from "../utils/debug.ts";
 import type { Selections } from "../state/state.ts";
@@ -204,14 +199,15 @@ export function resetRenderCharacterQueueForTests(): void {
  * are outside the `renderCharacter` performance measure; marks wrap compositing in `runRenderCharacter` only.
  */
 export async function renderCharacter(
+  catalog: CatalogReader,
   selections: Selections,
   bodyType: string,
   targetCanvas: HTMLCanvasElement | null = null,
 ): Promise<void> {
-  await catalogReady.onLayersReady;
+  await catalog.ready.onLayersReady;
 
   const p = renderCharacterSerial.then(() =>
-    runRenderCharacter(selections, bodyType, targetCanvas),
+    runRenderCharacter(catalog, selections, bodyType, targetCanvas),
   );
   renderCharacterSerial = p.then(
     () => {},
@@ -221,6 +217,7 @@ export async function renderCharacter(
 }
 
 async function runRenderCharacter(
+  catalog: CatalogReader,
   selections: Selections,
   bodyType: string,
   targetCanvas: HTMLCanvasElement | null,
@@ -258,7 +255,7 @@ async function runRenderCharacter(
 
     for (const [, selection] of Object.entries(selections)) {
       const { itemId, subId, variant } = selection;
-      const metaResult = getItemMerged(itemId);
+      const metaResult = catalog.getItemMerged(itemId);
       if (metaResult.isErr() || subId) continue;
       const meta = metaResult.value;
 
@@ -268,7 +265,7 @@ async function runRenderCharacter(
       }
 
       // Get Multiple Recolors If Available
-      const recolors = getMultiRecolors(defaultCatalog, itemId, selections);
+      const recolors = getMultiRecolors(catalog, itemId, selections);
 
       // Process all layers for this item
       for (let layerNum = 1; layerNum < 10; layerNum++) {
@@ -277,7 +274,7 @@ async function runRenderCharacter(
         const layer = meta.layers?.[layerKey];
         if (!layer) break;
 
-        const zPos = getZPos(defaultCatalog, itemId, layerNum);
+        const zPos = getZPos(catalog, itemId, layerNum);
 
         // Check if this layer has a custom animation
         if (layer.custom_animation) {
@@ -344,7 +341,7 @@ async function runRenderCharacter(
           }
 
           const pathResult = getSpritePath(
-            defaultCatalog,
+            catalog,
             itemId,
             variant ?? null,
             recolors,
@@ -472,7 +469,7 @@ async function runRenderCharacter(
     for (const { item, img, success } of loadedItems) {
       if (success && img) {
         const imageToDraw = await getImageToDraw(
-          defaultCatalog,
+          catalog,
           img,
           item.itemId,
           item.recolors,
@@ -547,7 +544,7 @@ async function runRenderCharacter(
         for (const { item: areaItem, img, success } of loadedCustomImages) {
           if (success && img) {
             const imageToUse = await getImageToDraw(
-              defaultCatalog,
+              catalog,
               img,
               areaItem.itemId,
               areaItem.recolors,
@@ -653,6 +650,7 @@ export function getCanvas(): Result<HTMLCanvasElement, CanvasNotInitialized> {
  * Returns a canvas with just this one item rendered.
  */
 export async function renderSingleItem(
+  catalog: CatalogReader,
   itemId: string,
   variant: string | null,
   recolors: Recolors,
@@ -661,7 +659,7 @@ export async function renderSingleItem(
   singleLayer: number | null = null,
   zipProfiler: ZipExportProfiler | null = null,
 ): Promise<HTMLCanvasElement | null> {
-  const metaResult = getItemMerged(itemId);
+  const metaResult = catalog.getItemMerged(itemId);
   if (metaResult.isErr()) {
     console.error("Item metadata not found:", itemId);
     return null;
@@ -714,11 +712,9 @@ export async function renderSingleItem(
     // Render all layers of this custom animation item
     const customSprites: { spritePath: string; zPos: number; yPos: number }[] =
       [];
-    const animsList = getSortedLayersByAnim(
-      defaultCatalog,
-      itemId,
-      true,
-    ).unwrapOr({} as Record<string, AnimationLayer[]>);
+    const animsList = getSortedLayersByAnim(catalog, itemId, true).unwrapOr(
+      {} as Record<string, AnimationLayer[]>,
+    );
     for (const animName in animsList) {
       for (let layerNum = 1; layerNum < 10; layerNum++) {
         if (singleLayer !== null && layerNum !== singleLayer) continue;
@@ -760,7 +756,7 @@ export async function renderSingleItem(
         for (const { item: sprite, img, success } of loadedSprites) {
           if (success && img) {
             const imageToDraw = await getImageToDraw(
-              defaultCatalog,
+              catalog,
               img,
               itemId,
               recolors,
@@ -797,7 +793,7 @@ export async function renderSingleItem(
     const layerKey = `layer_${layerNum}`;
     if (!meta.layers?.[layerKey]) break;
 
-    const zPos = getZPos(defaultCatalog, itemId, layerNum);
+    const zPos = getZPos(catalog, itemId, layerNum);
 
     // Add each animation for this layer
     for (const [animName, yPos] of Object.entries(ANIMATION_OFFSETS)) {
@@ -824,7 +820,7 @@ export async function renderSingleItem(
       }
 
       const pathResult = getSpritePath(
-        defaultCatalog,
+        catalog,
         itemId,
         variant,
         recolors,
@@ -870,7 +866,7 @@ export async function renderSingleItem(
         for (const { item: sprite, img, success } of loadedImages) {
           if (success && img) {
             const imageToDraw = await getImageToDraw(
-              defaultCatalog,
+              catalog,
               img,
               itemId,
               sprite.recolors,
@@ -891,6 +887,7 @@ export async function renderSingleItem(
  * Returns a canvas with just this one item's one animation rendered.
  */
 export async function renderSingleItemAnimation(
+  catalog: CatalogReader,
   itemId: string,
   variant: string | null,
   recolors: Recolors,
@@ -900,7 +897,7 @@ export async function renderSingleItemAnimation(
   singleLayer: number | null = null,
   zipProfiler: ZipExportProfiler | null = null,
 ): Promise<HTMLCanvasElement | null> {
-  const metaResult = getItemMerged(itemId);
+  const metaResult = catalog.getItemMerged(itemId);
   if (metaResult.isErr()) {
     console.error("Item metadata not found:", itemId);
     return null;
@@ -919,6 +916,7 @@ export async function renderSingleItemAnimation(
   if (hasCustomAnimation && customAnimations) {
     // Custom animation item - just return the full item canvas (custom animations are not split by standard animation)
     return await renderSingleItem(
+      catalog,
       itemId,
       variant,
       recolors,
@@ -959,7 +957,7 @@ export async function renderSingleItemAnimation(
     const layerKey = `layer_${layerNum}`;
     if (!meta.layers?.[layerKey]) break;
 
-    const zPos = getZPos(defaultCatalog, itemId, layerNum);
+    const zPos = getZPos(catalog, itemId, layerNum);
 
     // Check animation support
     if (animationName === "combat_idle") {
@@ -977,7 +975,7 @@ export async function renderSingleItemAnimation(
     }
 
     const pathResult = getSpritePath(
-      defaultCatalog,
+      catalog,
       itemId,
       variant,
       recolors,
@@ -1016,7 +1014,7 @@ export async function renderSingleItemAnimation(
       for (const { item: sprite, img, success } of loadedImages) {
         if (success && img) {
           const imageToDraw = await getImageToDraw(
-            defaultCatalog,
+            catalog,
             img,
             itemId,
             sprite.recolors,

--- a/sources/components/App.ts
+++ b/sources/components/App.ts
@@ -49,7 +49,11 @@ export const App: m.Component<AppAttrs, AppState> = {
       syncSelectionsToHash(vnode.attrs.catalog);
       if (window.canvasRenderer) {
         // Render to offscreen canvas (async)
-        renderCharacter(state.selections, state.bodyType).then(() => {
+        renderCharacter(
+          vnode.attrs.catalog,
+          state.selections,
+          state.bodyType,
+        ).then(() => {
           // Trigger redraw to update preview canvas after offscreen render completes
           m.redraw();
         });

--- a/sources/state/state.ts
+++ b/sources/state/state.ts
@@ -81,7 +81,8 @@ function createDefaultStateDeps(): StateDeps {
     selectDefaults,
     redraw: () => m.redraw(),
     syncSelectionsToHash: () => syncSelectionsToHash(defaultCatalog),
-    renderCharacter,
+    renderCharacter: (selections, bodyType) =>
+      renderCharacter(defaultCatalog, selections, bodyType),
     loadSelectionsFromHash,
     getCanvasRenderer: () =>
       (window as unknown as { canvasRenderer?: unknown }).canvasRenderer,

--- a/sources/state/zip.ts
+++ b/sources/state/zip.ts
@@ -286,6 +286,7 @@ export const exportSplitItemSheets = async (
         );
         try {
           const itemCanvas = await renderSingleItemFn(
+            defaultCatalog,
             itemId,
             variant ?? null,
             recolors,
@@ -461,6 +462,7 @@ export const exportSplitItemAnimations = async (
 
           try {
             const animCanvas = await renderSingleItemAnimationFn(
+              defaultCatalog,
               itemId,
               variant ?? null,
               recolors,

--- a/tests/canvas/renderer-issue-364_spec.js
+++ b/tests/canvas/renderer-issue-364_spec.js
@@ -6,7 +6,7 @@
  * Real sprite URLs (no global Image stub): avoids cache/global issues in the
  * shared `load-image` module. `try`/`finally` plus `resetRendererModuleState()`
  * (drawCalls, customAreaItems, addedCustomAnimations, initCanvas) plus
- * `resetImageLoadCache()` and restoring the app catalog keep later specs
+ * `resetImageLoadCache()` and an isolated catalog keep later specs
  * safe when this file is imported first (e.g. if test order is randomized later).
  */
 import { expect } from "chai";
@@ -22,11 +22,8 @@ import {
 } from "../../sources/canvas/renderer.ts";
 import { resetImageLoadCache } from "../../sources/canvas/load-image.ts";
 import { resetState } from "../../sources/state/hash.ts";
-import { resetCatalogForTests } from "../../sources/state/catalog.ts";
-import {
-  restoreAppCatalogAfterTest,
-  seedBrowserCatalog,
-} from "../browser-catalog-fixture.js";
+import { createCatalog } from "../../sources/state/catalog.ts";
+import { seedCatalog } from "../browser-catalog-fixture.js";
 import { state } from "../../sources/state/state.ts";
 
 const ISSUE_364_METADATA = {
@@ -48,13 +45,14 @@ const ISSUE_364_METADATA = {
 
 describe("canvas/renderer.ts issue #364 (addedCustomAnimations export)", () => {
   let sandbox;
+  let catalog;
 
   beforeEach(() => {
     sandbox = sinon.createSandbox();
     resetState();
     initCanvas();
-    resetCatalogForTests();
-    seedBrowserCatalog(ISSUE_364_METADATA);
+    catalog = createCatalog();
+    seedCatalog(catalog, ISSUE_364_METADATA);
     state.selections = {
       slot: {
         itemId: "issue364_wheel_item",
@@ -77,18 +75,17 @@ describe("canvas/renderer.ts issue #364 (addedCustomAnimations export)", () => {
     initCanvas();
   }
 
-  afterEach(async () => {
+  afterEach(() => {
     resetImageLoadCache();
     resetRendererModuleState();
     if (sandbox) {
       sandbox.restore();
       sandbox = null;
     }
-    await restoreAppCatalogAfterTest();
   });
 
   it("records custom animation names on the exported addedCustomAnimations set after renderCharacter", async () => {
-    await renderCharacter(state.selections, "male");
+    await renderCharacter(catalog, state.selections, "male");
 
     expect(
       addedCustomAnimations.size,

--- a/tests/canvas/renderer_spec.js
+++ b/tests/canvas/renderer_spec.js
@@ -31,11 +31,8 @@ import {
 } from "../../sources/canvas/renderer.ts";
 import { resetImageLoadCache } from "../../sources/canvas/load-image.ts";
 import { resetState } from "../../sources/state/hash.ts";
-import { resetCatalogForTests } from "../../sources/state/catalog.ts";
-import {
-  restoreAppCatalogAfterTest,
-  seedBrowserCatalog,
-} from "../browser-catalog-fixture.js";
+import { createCatalog } from "../../sources/state/catalog.ts";
+import { seedCatalog } from "../browser-catalog-fixture.js";
 import { state } from "../../sources/state/state.ts";
 import {
   ANIMATION_CONFIGS,
@@ -188,6 +185,7 @@ describe("canvas/renderer.ts", () => {
     this.timeout(15_000);
 
     let sandbox;
+    let catalog;
 
     beforeEach(() => {
       sandbox = sinon.createSandbox();
@@ -195,13 +193,13 @@ describe("canvas/renderer.ts", () => {
       state.customUploadedImage = null;
       state.customImageZPos = 100;
       initCanvas();
-      resetCatalogForTests();
+      catalog = createCatalog();
       if (typeof m !== "undefined" && m.redraw) {
         sandbox.stub(m, "redraw");
       }
     });
 
-    afterEach(async () => {
+    afterEach(() => {
       resetImageLoadCache();
       resetRendererModuleState();
       state.customUploadedImage = null;
@@ -209,12 +207,12 @@ describe("canvas/renderer.ts", () => {
         sandbox.restore();
         sandbox = null;
       }
-      await restoreAppCatalogAfterTest();
     });
 
     it("skips items whose required list excludes the body type", async () => {
-      seedBrowserCatalog({ walk_only: walkItemMeta() });
+      seedCatalog(catalog, { walk_only: walkItemMeta() });
       await renderCharacter(
+        catalog,
         {
           slot: {
             itemId: "walk_only",
@@ -228,9 +226,10 @@ describe("canvas/renderer.ts", () => {
     });
 
     it("skips selections that have a subId", async () => {
-      seedBrowserCatalog({ walk_only: walkItemMeta() });
+      seedCatalog(catalog, { walk_only: walkItemMeta() });
       // `subId` is checked for truthiness in the renderer (0 would not skip).
       await renderCharacter(
+        catalog,
         {
           slot: {
             itemId: "walk_only",
@@ -245,8 +244,9 @@ describe("canvas/renderer.ts", () => {
     });
 
     it("queues walk and omits alias folders for a walk-only item", async () => {
-      seedBrowserCatalog({ walk_only: walkItemMeta() });
+      seedCatalog(catalog, { walk_only: walkItemMeta() });
       await renderCharacter(
+        catalog,
         {
           slot: {
             itemId: "walk_only",
@@ -265,10 +265,11 @@ describe("canvas/renderer.ts", () => {
     });
 
     it("maps combat metadata to combat_idle drawCalls", async () => {
-      seedBrowserCatalog({
+      seedCatalog(catalog, {
         combat_item: walkItemMeta({ animations: ["combat"] }),
       });
       await renderCharacter(
+        catalog,
         {
           slot: {
             itemId: "combat_item",
@@ -282,10 +283,11 @@ describe("canvas/renderer.ts", () => {
     });
 
     it("maps 1h_slash metadata to backslash drawCalls", async () => {
-      seedBrowserCatalog({
+      seedCatalog(catalog, {
         slash_item: walkItemMeta({ animations: ["1h_slash"] }),
       });
       await renderCharacter(
+        catalog,
         {
           slot: {
             itemId: "slash_item",
@@ -299,10 +301,11 @@ describe("canvas/renderer.ts", () => {
     });
 
     it("maps 1h_halfslash metadata to halfslash drawCalls", async () => {
-      seedBrowserCatalog({
+      seedCatalog(catalog, {
         half_item: walkItemMeta({ animations: ["1h_halfslash"] }),
       });
       await renderCharacter(
+        catalog,
         {
           slot: {
             itemId: "half_item",
@@ -316,7 +319,7 @@ describe("canvas/renderer.ts", () => {
     });
 
     it("sorts drawCalls by ascending zPos", async () => {
-      seedBrowserCatalog({
+      seedCatalog(catalog, {
         layered: walkItemMeta({
           layers: {
             layer_1: {
@@ -331,6 +334,7 @@ describe("canvas/renderer.ts", () => {
         }),
       });
       await renderCharacter(
+        catalog,
         {
           slot: {
             itemId: "layered",
@@ -349,13 +353,14 @@ describe("canvas/renderer.ts", () => {
     });
 
     it("sets needsRecolor for body-body with a non-light variant", async () => {
-      seedBrowserCatalog({
+      seedCatalog(catalog, {
         "body-body": walkItemMeta({
           name: "Body Color",
           type_name: "body",
         }),
       });
       await renderCharacter(
+        catalog,
         {
           body: {
             itemId: "body-body",
@@ -372,11 +377,11 @@ describe("canvas/renderer.ts", () => {
     });
 
     it("queues custom-upload drawCalls from state.customUploadedImage", async () => {
-      seedBrowserCatalog({});
+      seedCatalog(catalog, {});
       state.customUploadedImage = await imageFromFilledCanvas(8, 8, "#00ff00");
       state.customImageZPos = 42;
 
-      await renderCharacter({}, "male");
+      await renderCharacter(catalog, {}, "male");
 
       const customCalls = drawCalls.filter((d) => d.itemId === "custom-upload");
       expect(customCalls.length).to.be.at.least(1);
@@ -391,13 +396,14 @@ describe("canvas/renderer.ts", () => {
     this.timeout(15_000);
 
     let sandbox;
+    let catalog;
 
     beforeEach(() => {
       sandbox = sinon.createSandbox();
       resetState();
       initCanvas();
-      resetCatalogForTests();
-      seedBrowserCatalog({
+      catalog = createCatalog();
+      seedCatalog(catalog, {
         wheel_item: WHEELCHAIR_ITEM_META,
       });
       if (typeof m !== "undefined" && m.redraw) {
@@ -405,18 +411,18 @@ describe("canvas/renderer.ts", () => {
       }
     });
 
-    afterEach(async () => {
+    afterEach(() => {
       resetImageLoadCache();
       resetRendererModuleState();
       if (sandbox) {
         sandbox.restore();
         sandbox = null;
       }
-      await restoreAppCatalogAfterTest();
     });
 
     it("grows the canvas and records custom_sprite area items for wheelchair", async () => {
       await renderCharacter(
+        catalog,
         {
           slot: {
             itemId: "wheel_item",
@@ -440,30 +446,31 @@ describe("canvas/renderer.ts", () => {
     this.timeout(15_000);
 
     let sandbox;
+    let catalog;
 
     beforeEach(() => {
       sandbox = sinon.createSandbox();
       resetState();
       initCanvas();
-      resetCatalogForTests();
+      catalog = createCatalog();
       if (typeof m !== "undefined" && m.redraw) {
         sandbox.stub(m, "redraw");
       }
     });
 
-    afterEach(async () => {
+    afterEach(() => {
       resetImageLoadCache();
       resetRendererModuleState();
       if (sandbox) {
         sandbox.restore();
         sandbox = null;
       }
-      await restoreAppCatalogAfterTest();
     });
 
     it("returns null for a missing item", async () => {
-      seedBrowserCatalog({});
+      seedCatalog(catalog, {});
       const result = await renderSingleItem(
+        catalog,
         "does_not_exist",
         null,
         null,
@@ -474,8 +481,9 @@ describe("canvas/renderer.ts", () => {
     });
 
     it("returns null for an unsupported body type", async () => {
-      seedBrowserCatalog({ walk_only: walkItemMeta() });
+      seedCatalog(catalog, { walk_only: walkItemMeta() });
       const result = await renderSingleItem(
+        catalog,
         "walk_only",
         "olive",
         null,
@@ -486,8 +494,9 @@ describe("canvas/renderer.ts", () => {
     });
 
     it("returns null for an unknown animation name", async () => {
-      seedBrowserCatalog({ walk_only: walkItemMeta() });
+      seedCatalog(catalog, { walk_only: walkItemMeta() });
       const result = await renderSingleItemAnimation(
+        catalog,
         "walk_only",
         "olive",
         null,
@@ -499,9 +508,10 @@ describe("canvas/renderer.ts", () => {
     });
 
     it("returns a standard sheet-sized canvas for a walk item", async () => {
-      seedBrowserCatalog({ walk_only: walkItemMeta() });
+      seedCatalog(catalog, { walk_only: walkItemMeta() });
       // Truthy recolors omit the variant segment so paths hit existing walk.png.
       const result = await renderSingleItem(
+        catalog,
         "walk_only",
         null,
         { misc: "unused" },
@@ -514,9 +524,10 @@ describe("canvas/renderer.ts", () => {
     });
 
     it("returns a single-anim canvas with height num * FRAME_SIZE", async () => {
-      seedBrowserCatalog({ walk_only: walkItemMeta() });
+      seedCatalog(catalog, { walk_only: walkItemMeta() });
       const walk = ANIMATION_CONFIGS.walk;
       const result = await renderSingleItemAnimation(
+        catalog,
         "walk_only",
         null,
         { misc: "unused" },
@@ -530,8 +541,9 @@ describe("canvas/renderer.ts", () => {
     });
 
     it("draws content into the walk band for a successful single-item render", async () => {
-      seedBrowserCatalog({ walk_only: walkItemMeta() });
+      seedCatalog(catalog, { walk_only: walkItemMeta() });
       const result = await renderSingleItem(
+        catalog,
         "walk_only",
         null,
         { misc: "unused" },
@@ -548,8 +560,9 @@ describe("canvas/renderer.ts", () => {
     });
 
     it("returns a taller-than-sheet canvas for a custom-animation-only item", async () => {
-      seedBrowserCatalog({ wheel_item: WHEELCHAIR_ITEM_META });
+      seedCatalog(catalog, { wheel_item: WHEELCHAIR_ITEM_META });
       const result = await renderSingleItem(
+        catalog,
         "wheel_item",
         "brass",
         null,

--- a/tests/fixtures/issue-382/issue382-golden-runner.js
+++ b/tests/fixtures/issue-382/issue382-golden-runner.js
@@ -24,6 +24,7 @@ import {
 } from "../../../sources/state/zip.ts";
 import { resetState } from "../../../sources/state/hash.ts";
 import { state } from "../../../sources/state/state.ts";
+import { defaultCatalog } from "../../../sources/state/catalog.ts";
 import { importStateFromJSON } from "../../../sources/state/json.ts";
 import issue382ItemMetadata from "./issue-382-itemdata.js";
 import issue382Selections from "./issue-382-selections.js";
@@ -79,7 +80,7 @@ async function runGoldens() {
   ctx.fillRect(0, 0, SHEET_WIDTH, SHEET_HEIGHT);
 
   setStatus("Rendering character...");
-  await renderCharacter(state.selections, state.bodyType);
+  await renderCharacter(defaultCatalog, state.selections, state.bodyType);
 
   const out = {};
 

--- a/tests/state/zip-issue-382_spec.js
+++ b/tests/state/zip-issue-382_spec.js
@@ -31,6 +31,7 @@ import {
 } from "../../sources/state/zip.ts";
 import { resetState } from "../../sources/state/hash.ts";
 import { state } from "../../sources/state/state.ts";
+import { defaultCatalog } from "../../sources/state/catalog.ts";
 import { importStateFromJSON } from "../../sources/state/json.ts";
 import issue382ItemMetadata from "../fixtures/issue-382/issue-382-itemdata.js";
 import issue382Selections from "../fixtures/issue-382/issue-382-selections.js";
@@ -89,7 +90,7 @@ describe("state/zip.ts issue #382 regression (longsword + full outfit)", () => {
     ctx.fillStyle = "#445566";
     ctx.fillRect(0, 0, SHEET_WIDTH, SHEET_HEIGHT);
 
-    await renderCharacter(state.selections, state.bodyType);
+    await renderCharacter(defaultCatalog, state.selections, state.bodyType);
   });
 
   afterEach(async () => {

--- a/tests/state/zip_spec.js
+++ b/tests/state/zip_spec.js
@@ -361,12 +361,13 @@ describe("state/zip.ts", () => {
 
       expect(renderStub.callCount).to.equal(bodyLayers.length);
       const renderCall = renderStub.firstCall;
-      expect(renderCall.args[0]).to.equal("body");
-      expect(renderCall.args[1]).to.equal("light");
-      expect(renderCall.args[2]).to.equal(null);
-      expect(renderCall.args[3]).to.equal(state.bodyType);
-      expect(renderCall.args[4]).to.equal(state.selections);
-      expect(renderCall.args[5]).to.equal(bodyLayers[0].layerNum);
+      expect(renderCall.args[0]).to.equal(defaultCatalog);
+      expect(renderCall.args[1]).to.equal("body");
+      expect(renderCall.args[2]).to.equal("light");
+      expect(renderCall.args[3]).to.equal(null);
+      expect(renderCall.args[4]).to.equal(state.bodyType);
+      expect(renderCall.args[5]).to.equal(state.selections);
+      expect(renderCall.args[6]).to.equal(bodyLayers[0].layerNum);
     });
 
     it("writes PNG blobs under items/ when render succeeds", async () => {
@@ -775,13 +776,14 @@ describe("state/zip.ts", () => {
 
       expect(renderStub.callCount).to.equal(bodyLayers.length);
       const rc = renderStub.firstCall;
-      expect(rc.args[0]).to.equal("body");
-      expect(rc.args[1]).to.equal("light");
-      expect(rc.args[2]).to.equal(null);
-      expect(rc.args[3]).to.equal(state.bodyType);
-      expect(rc.args[4]).to.equal("walk");
-      expect(rc.args[5]).to.equal(state.selections);
-      expect(rc.args[6]).to.equal(bodyLayers[0].layerNum);
+      expect(rc.args[0]).to.equal(defaultCatalog);
+      expect(rc.args[1]).to.equal("body");
+      expect(rc.args[2]).to.equal("light");
+      expect(rc.args[3]).to.equal(null);
+      expect(rc.args[4]).to.equal(state.bodyType);
+      expect(rc.args[5]).to.equal("walk");
+      expect(rc.args[6]).to.equal(state.selections);
+      expect(rc.args[7]).to.equal(bodyLayers[0].layerNum);
     });
 
     it("writes metadata.json with standardAnimations.exported / failed maps per animation (walk only in fixture)", async () => {

--- a/tests/state/zip_spec.js
+++ b/tests/state/zip_spec.js
@@ -248,7 +248,7 @@ describe("state/zip.ts", () => {
 
       const addSpy = sinon.spy(addAnimationSliceToZip);
 
-      await renderCharacter(state.selections, "male");
+      await renderCharacter(defaultCatalog, state.selections, "male");
       await exportSplitAnimations({ addAnimationSliceToZip: addSpy });
 
       const customPng = addSpy
@@ -866,7 +866,7 @@ describe("state/zip.ts", () => {
 
       const loadImageStub = sandbox.stub().resolves(nonEmptyAnimCanvas());
 
-      await renderCharacter(state.selections, "male");
+      await renderCharacter(defaultCatalog, state.selections, "male");
       await exportSplitItemAnimations({
         loadImage: loadImageStub,
       });
@@ -984,7 +984,7 @@ describe("state/zip.ts", () => {
         addStandardAnimationToZipCustomFolder,
       );
 
-      await renderCharacter(state.selections, "male");
+      await renderCharacter(defaultCatalog, state.selections, "male");
       await exportSplitItemAnimations({
         loadImage: loadImageStub,
         addAnimationSliceToZip: addAnimationSliceToZipSpy,
@@ -1095,7 +1095,7 @@ describe("state/zip.ts", () => {
         addStandardAnimationToZipCustomFolder,
       );
 
-      await renderCharacter(state.selections, "male");
+      await renderCharacter(defaultCatalog, state.selections, "male");
       await exportSplitItemAnimations({
         loadImage: loadImageStub,
         getImageToDraw: getImageToDrawStub,
@@ -1360,7 +1360,7 @@ describe("state/zip.ts", () => {
         },
       };
 
-      await renderCharacter(state.selections, "male");
+      await renderCharacter(defaultCatalog, state.selections, "male");
 
       const extractStub = sandbox.stub().callsFake(() => smallAnimCanvas());
       const framesStub = sinon.stub().returns({});


### PR DESCRIPTION
## Summary

  - Inject CatalogReader into the character and single-item renderer APIs.
  - Use the supplied catalog for metadata, layers, paths, recoloring, and readiness.
  - Pass the application catalog from App.
  - Preserve the existing state dependency interface by binding defaultCatalog in its adapter.
  - Explicitly use defaultCatalog in transitional ZIP and fixture workflows.
  - Isolate renderer tests with fresh catalog instances to prevent cross-test contamination.