### PR TITLE
feat: migrate ZIP and filename to catalog DI

### DIFF
--- a/scripts/zip/zip-export-profile-runner.js
+++ b/scripts/zip/zip-export-profile-runner.js
@@ -117,22 +117,22 @@ async function runProfiles(opts = {}) {
   await renderCharacter(defaultCatalog, state.selections, state.bodyType);
 
   if (run("splitAnimations")) {
-    await exportSplitAnimations();
+    await exportSplitAnimations(defaultCatalog);
     state.zipByAnimation.isRunning = false;
   }
 
   if (run("splitItemSheets")) {
-    await exportSplitItemSheets();
+    await exportSplitItemSheets(defaultCatalog);
     state.zipByItem.isRunning = false;
   }
 
   if (run("splitItemAnimations")) {
-    await exportSplitItemAnimations();
+    await exportSplitItemAnimations(defaultCatalog);
     state.zipByAnimimationAndItem.isRunning = false;
   }
 
   if (run("individualFrames")) {
-    await exportIndividualFrames();
+    await exportIndividualFrames(defaultCatalog);
     if (state.zipIndividualFrames) {
       state.zipIndividualFrames.isRunning = false;
     }

--- a/sources/components/download/Download.ts
+++ b/sources/components/download/Download.ts
@@ -117,7 +117,7 @@ export const Download: m.Component<{ catalog: CatalogReader }> = {
             {
               disabled: zipDisabled,
               title: zipDisabled ? zipExportTitle : undefined,
-              onclick: exportSplitAnimations,
+              onclick: () => exportSplitAnimations(vnode.attrs.catalog),
             },
             "ZIP: Split by animation",
           ),
@@ -127,7 +127,7 @@ export const Download: m.Component<{ catalog: CatalogReader }> = {
             {
               disabled: zipDisabled,
               title: zipDisabled ? zipExportTitle : undefined,
-              onclick: exportSplitItemSheets,
+              onclick: () => exportSplitItemSheets(vnode.attrs.catalog),
             },
             "ZIP: Split by item",
           ),
@@ -137,7 +137,7 @@ export const Download: m.Component<{ catalog: CatalogReader }> = {
             {
               disabled: zipDisabled,
               title: zipDisabled ? zipExportTitle : undefined,
-              onclick: exportSplitItemAnimations,
+              onclick: () => exportSplitItemAnimations(vnode.attrs.catalog),
             },
             "ZIP: Split by animation and item",
           ),
@@ -147,7 +147,7 @@ export const Download: m.Component<{ catalog: CatalogReader }> = {
             {
               disabled: zipDisabled,
               title: zipDisabled ? zipExportTitle : undefined,
-              onclick: exportIndividualFrames,
+              onclick: () => exportIndividualFrames(vnode.attrs.catalog),
             },
             "ZIP: Split by animation and frame",
           ),

--- a/sources/state/zip.ts
+++ b/sources/state/zip.ts
@@ -4,7 +4,7 @@ import {
   FRAME_SIZE,
   DIRECTIONS,
 } from "./constants.ts";
-import { defaultCatalog, getItemMerged } from "./catalog.ts";
+import type { CatalogReader } from "./catalog.ts";
 import {
   extractAnimationFromCanvas,
   renderSingleItem,
@@ -68,6 +68,7 @@ type ExportSplitAnimationsDeps = {
 
 // Export ZIP - Split by animation
 export const exportSplitAnimations = async (
+  catalog: CatalogReader,
   deps: Partial<ExportSplitAnimationsDeps> = {},
 ): Promise<void> => {
   const baseAddAnimationSliceToZip =
@@ -176,7 +177,7 @@ export const exportSplitAnimations = async (
 
     await profiler.phase("staticFiles", async () => {
       addCharacterJsonAndCredits(
-        defaultCatalog,
+        catalog,
         zip,
         creditsFolder,
         state!,
@@ -232,6 +233,7 @@ type ExportSplitItemSheetsDeps = {
 
 // Export ZIP - Split by item
 export const exportSplitItemSheets = async (
+  catalog: CatalogReader,
   deps: Partial<ExportSplitItemSheetsDeps> = {},
 ): Promise<void> => {
   const baseAddCanvasToZip = deps.addCanvasToZip ?? addCanvasToZip;
@@ -265,20 +267,17 @@ export const exportSplitItemSheets = async (
     for (const [, selection] of Object.entries(state.selections)) {
       const { itemId, variant, name } = selection;
       const itemLayers = getSortedLayersWithCustomFallback(
-        defaultCatalog,
+        catalog,
         itemId,
       ).unwrapOr([]);
 
       // Get Multiple Recolors If Available
-      const recolors = getMultiRecolors(
-        defaultCatalog,
-        itemId,
-        state.selections,
-      );
+      const recolors = getMultiRecolors(catalog, itemId, state.selections);
 
       // Render each layer of the item separately
       for (const layer of itemLayers) {
         const fileName = getItemFileName(
+          catalog,
           itemId,
           String(variant),
           name,
@@ -286,7 +285,7 @@ export const exportSplitItemSheets = async (
         );
         try {
           const itemCanvas = await renderSingleItemFn(
-            defaultCatalog,
+            catalog,
             itemId,
             variant ?? null,
             recolors,
@@ -310,7 +309,7 @@ export const exportSplitItemSheets = async (
 
     await profiler.phase("staticFiles", async () => {
       addCharacterJsonAndCredits(
-        defaultCatalog,
+        catalog,
         zip,
         creditsFolder,
         state!,
@@ -356,6 +355,7 @@ type ExportSplitItemAnimationsDeps = {
 
 // Export ZIP - Split by animation and item
 export const exportSplitItemAnimations = async (
+  catalog: CatalogReader,
   deps: Partial<ExportSplitItemAnimationsDeps> = {},
 ): Promise<void> => {
   const baseAddAnimationSliceToZip =
@@ -427,7 +427,7 @@ export const exportSplitItemAnimations = async (
       // Export each item for this animation
       for (const [, selection] of Object.entries(state.selections)) {
         const { itemId, variant, name } = selection;
-        const metaResult = getItemMerged(itemId);
+        const metaResult = catalog.getItemMerged(itemId);
         if (
           metaResult.isErr() ||
           !metaResult.value.animations.includes(anim.value)
@@ -442,18 +442,15 @@ export const exportSplitItemAnimations = async (
         }
 
         // Get Multiple Recolors If Available
-        const recolors = getMultiRecolors(
-          defaultCatalog,
-          itemId,
-          state.selections,
-        );
+        const recolors = getMultiRecolors(catalog, itemId, state.selections);
 
         const itemLayers = getSortedLayersWithCustomFallback(
-          defaultCatalog,
+          catalog,
           itemId,
         ).unwrapOr([]);
         for (const layer of itemLayers) {
           const fileName = getItemFileName(
+            catalog,
             itemId,
             String(variant),
             name,
@@ -462,7 +459,7 @@ export const exportSplitItemAnimations = async (
 
           try {
             const animCanvas = await renderSingleItemAnimationFn(
-              defaultCatalog,
+              catalog,
               itemId,
               variant ?? null,
               recolors,
@@ -498,6 +495,7 @@ export const exportSplitItemAnimations = async (
 
         const spritePath = layer.spritePath;
         const itemFileName = getItemFileName(
+          catalog,
           layer.itemId,
           String(layer.variant),
           layer.name ?? "",
@@ -526,7 +524,7 @@ export const exportSplitItemAnimations = async (
             "render_composite_customItemSprite",
             async () => {
               imgCanvas = await getImageToDrawFn(
-                defaultCatalog,
+                catalog,
                 img!,
                 layer.itemId,
                 layer.recolors,
@@ -579,7 +577,7 @@ export const exportSplitItemAnimations = async (
 
     await profiler.phase("staticFiles", async () => {
       addCharacterJsonAndCredits(
-        defaultCatalog,
+        catalog,
         zip,
         creditsFolder,
         state!,
@@ -660,6 +658,7 @@ type BlobTaskResult = BlobTask & {
 
 // Export ZIP - Individual animation frames
 export const exportIndividualFrames = async (
+  catalog: CatalogReader,
   deps: Partial<ExportIndividualFramesDeps> = {},
 ): Promise<void> => {
   const extractAnimationFromCanvasFn =
@@ -891,7 +890,7 @@ export const exportIndividualFrames = async (
 
     await profiler.phase("staticFiles", async () => {
       addCharacterJsonAndCredits(
-        defaultCatalog,
+        catalog,
         zip,
         creditsFolder,
         state!,

--- a/sources/utils/fileName.ts
+++ b/sources/utils/fileName.ts
@@ -1,4 +1,4 @@
-import { getItemMerged } from "../state/catalog.ts";
+import type { CatalogReader } from "../state/catalog.ts";
 
 function addExtensionIfMissing(filename: string, extension: string): string {
   if (filename.toLowerCase().endsWith(extension.toLowerCase())) {
@@ -8,13 +8,14 @@ function addExtensionIfMissing(filename: string, extension: string): string {
 }
 
 export function getItemFileName(
+  catalog: CatalogReader,
   itemId: string,
   variant: string,
   name: string,
   layerNum: number = 1,
   zOverride?: number,
 ): string {
-  const result = getItemMerged(itemId);
+  const result = catalog.getItemMerged(itemId);
   if (result.isErr()) return addExtensionIfMissing(name, "png");
 
   // Get zPos from specified layer

--- a/tests/fixtures/issue-382/issue382-golden-runner.js
+++ b/tests/fixtures/issue-382/issue382-golden-runner.js
@@ -85,22 +85,22 @@ async function runGoldens() {
   const out = {};
 
   setStatus("Exporting split animations...");
-  await exportSplitAnimations();
+  await exportSplitAnimations(defaultCatalog);
   out.splitAnimations = sortedZipKeys(fakeZip);
   state.zipByAnimation.isRunning = false;
 
   setStatus("Exporting split item sheets...");
-  await exportSplitItemSheets();
+  await exportSplitItemSheets(defaultCatalog);
   out.splitItemSheets = sortedZipKeys(fakeZip);
   state.zipByItem.isRunning = false;
 
   setStatus("Exporting split item animations...");
-  await exportSplitItemAnimations();
+  await exportSplitItemAnimations(defaultCatalog);
   out.splitItemAnimations = sortedZipKeys(fakeZip);
   state.zipByAnimationAndItem.isRunning = false;
 
   setStatus("Exporting individual frames...");
-  await exportIndividualFrames();
+  await exportIndividualFrames(defaultCatalog);
   out.individualFrames = sortedZipKeys(fakeZip);
   if (state.zipIndividualFrames) {
     state.zipIndividualFrames.isRunning = false;

--- a/tests/state/zip-issue-382_spec.js
+++ b/tests/state/zip-issue-382_spec.js
@@ -107,7 +107,7 @@ describe("state/zip.ts issue #382 regression (longsword + full outfit)", () => {
   });
 
   it("exportSplitAnimations creates the expected zip paths", async () => {
-    await exportSplitAnimations();
+    await exportSplitAnimations(defaultCatalog);
     expect(sortedZipKeys(fakeZip)).to.deep.equal(
       [...issue382ZipPathsSplitAnimations].sort(),
     );
@@ -115,7 +115,7 @@ describe("state/zip.ts issue #382 regression (longsword + full outfit)", () => {
   });
 
   it("exportSplitItemSheets creates the expected zip paths", async () => {
-    await exportSplitItemSheets();
+    await exportSplitItemSheets(defaultCatalog);
     expect(sortedZipKeys(fakeZip)).to.deep.equal(
       [...issue382ZipPathsSplitItemSheets].sort(),
     );
@@ -123,7 +123,7 @@ describe("state/zip.ts issue #382 regression (longsword + full outfit)", () => {
   });
 
   it("exportSplitItemAnimations creates the expected zip paths (custom folders include standard layers)", async () => {
-    await exportSplitItemAnimations();
+    await exportSplitItemAnimations(defaultCatalog);
     expect(sortedZipKeys(fakeZip)).to.deep.equal(
       [...issue382ZipPathsSplitItemAnimations].sort(),
     );
@@ -136,7 +136,7 @@ describe("state/zip.ts issue #382 regression (longsword + full outfit)", () => {
   });
 
   it("exportIndividualFrames creates the expected zip paths (golden list)", async () => {
-    await exportIndividualFrames();
+    await exportIndividualFrames(defaultCatalog);
     expect(sortedZipKeys(fakeZip)).to.deep.equal(
       [...issue382ZipPathsIndividualFrames].sort(),
     );

--- a/tests/state/zip_spec.js
+++ b/tests/state/zip_spec.js
@@ -161,7 +161,7 @@ describe("state/zip.ts", () => {
     it("calls addCanvasToZip for each standard animation with folder, file name, and extracted canvas (no crop rect)", async () => {
       const addSpy = sinon.spy(addCanvasToZip);
 
-      await exportSplitAnimations({ addCanvasToZip: addSpy });
+      await exportSplitAnimations(defaultCatalog, { addCanvasToZip: addSpy });
 
       const standardCalls = addSpy
         .getCalls()
@@ -181,7 +181,7 @@ describe("state/zip.ts", () => {
     });
 
     it("writes metadata.json with standardAnimations.exported listing each successfully written standard animation id", async () => {
-      await exportSplitAnimations();
+      await exportSplitAnimations(defaultCatalog);
 
       const metadataEntry = fakeZip.files.get("credits/metadata.json");
       expect(metadataEntry, "metadata.json should exist").to.exist;
@@ -197,7 +197,7 @@ describe("state/zip.ts", () => {
         return fakeZip;
       };
 
-      await exportSplitAnimations();
+      await exportSplitAnimations(defaultCatalog);
 
       const metadataEntry = fakeZip.files.get("credits/metadata.json");
       const metadata = JSON.parse(metadataEntry);
@@ -211,14 +211,14 @@ describe("state/zip.ts", () => {
     });
 
     it("noExport: still writes flat standard PNGs for animations marked noExport (e.g. watering, 1h_slash)", async () => {
-      await exportSplitAnimations();
+      await exportSplitAnimations(defaultCatalog);
 
       expect(fakeZip.files.get("standard/watering.png")).to.exist;
       expect(fakeZip.files.get("standard/1h_slash.png")).to.exist;
     });
 
     it("includes character.json, credits credits.txt/credits.csv, and credits/metadata.json", async () => {
-      await exportSplitAnimations();
+      await exportSplitAnimations(defaultCatalog);
 
       expect(fakeZip.files.get("character.json")).to.exist;
       expect(fakeZip.files.get("credits/credits.txt")).to.exist;
@@ -249,7 +249,9 @@ describe("state/zip.ts", () => {
       const addSpy = sinon.spy(addAnimationSliceToZip);
 
       await renderCharacter(defaultCatalog, state.selections, "male");
-      await exportSplitAnimations({ addAnimationSliceToZip: addSpy });
+      await exportSplitAnimations(defaultCatalog, {
+        addAnimationSliceToZip: addSpy,
+      });
 
       const customPng = addSpy
         .getCalls()
@@ -327,7 +329,7 @@ describe("state/zip.ts", () => {
       const renderStub = sandbox.stub().resolves(nonEmptyItemCanvas());
       const addSpy = sinon.spy(addCanvasToZip);
 
-      await exportSplitItemSheets({
+      await exportSplitItemSheets(defaultCatalog, {
         renderSingleItem: renderStub,
         addCanvasToZip: addSpy,
       });
@@ -342,6 +344,7 @@ describe("state/zip.ts", () => {
       expect(bodyLayers.length).to.be.at.least(1);
 
       const expectedFileName = getItemFileName(
+        defaultCatalog,
         "body",
         "light",
         "Body color (light)",
@@ -373,7 +376,7 @@ describe("state/zip.ts", () => {
     it("writes PNG blobs under items/ when render succeeds", async () => {
       const renderStub = sandbox.stub().resolves(nonEmptyItemCanvas());
 
-      await exportSplitItemSheets({
+      await exportSplitItemSheets(defaultCatalog, {
         renderSingleItem: renderStub,
       });
 
@@ -383,6 +386,7 @@ describe("state/zip.ts", () => {
         true,
       )._unsafeUnwrap();
       const expectedFileName = getItemFileName(
+        defaultCatalog,
         "body",
         "light",
         "Body color (light)",
@@ -396,7 +400,7 @@ describe("state/zip.ts", () => {
     it("includes character.json and credits credits.txt/credits.csv but not credits/metadata.json", async () => {
       const renderStub = sandbox.stub().resolves(nonEmptyItemCanvas());
 
-      await exportSplitItemSheets({
+      await exportSplitItemSheets(defaultCatalog, {
         renderSingleItem: renderStub,
       });
 
@@ -427,7 +431,9 @@ describe("state/zip.ts", () => {
 
       const renderStub = sandbox.stub().resolves(nonEmptyItemCanvas());
 
-      await exportSplitItemSheets({ renderSingleItem: renderStub });
+      await exportSplitItemSheets(defaultCatalog, {
+        renderSingleItem: renderStub,
+      });
 
       const bodyLayers = getSortedLayers(
         defaultCatalog,
@@ -440,12 +446,14 @@ describe("state/zip.ts", () => {
         true,
       )._unsafeUnwrap();
       const firstFileName = getItemFileName(
+        defaultCatalog,
         "body",
         "light",
         "Body color (light)",
         bodyLayers[0].layerNum,
       );
       const secondFileName = getItemFileName(
+        defaultCatalog,
         "heads_human_male",
         "light",
         "Human male (light)",
@@ -490,7 +498,9 @@ describe("state/zip.ts", () => {
 
       const renderStub = sandbox.stub().resolves(nonEmptyItemCanvas());
 
-      await exportSplitItemSheets({ renderSingleItem: renderStub });
+      await exportSplitItemSheets(defaultCatalog, {
+        renderSingleItem: renderStub,
+      });
 
       const bodyLayers = getSortedLayers(
         defaultCatalog,
@@ -512,18 +522,21 @@ describe("state/zip.ts", () => {
         "longsword",
       )._unsafeUnwrap();
       const firstFileName = getItemFileName(
+        defaultCatalog,
         "body",
         "light",
         "Body color (light)",
         bodyLayers[0].layerNum,
       );
       const secondFileName = getItemFileName(
+        defaultCatalog,
         "heads_human_male",
         "light",
         "Human male (light)",
         headLayers[0].layerNum,
       );
       const thirdFileName = getItemFileName(
+        defaultCatalog,
         "longsword",
         "longsword",
         "Longsword (longsword)",
@@ -570,7 +583,7 @@ describe("state/zip.ts", () => {
         const renderStub = sandbox.stub().resolves(nonEmptyItemCanvas());
         const addSpy = sinon.spy(addCanvasToZip);
 
-        await exportSplitItemSheets({
+        await exportSplitItemSheets(defaultCatalog, {
           renderSingleItem: renderStub,
           addCanvasToZip: addSpy,
         });
@@ -581,6 +594,7 @@ describe("state/zip.ts", () => {
           false,
         )._unsafeUnwrap();
         const expectedFileName = getItemFileName(
+          defaultCatalog,
           "custom_only_whip",
           "light",
           "Custom Whip",
@@ -743,7 +757,7 @@ describe("state/zip.ts", () => {
       const renderStub = sandbox.stub().resolves(nonEmptyAnimCanvas());
       const addSpy = sinon.spy(addCanvasToZip);
 
-      await exportSplitItemAnimations({
+      await exportSplitItemAnimations(defaultCatalog, {
         renderSingleItemAnimation: renderStub,
         addCanvasToZip: addSpy,
       });
@@ -763,6 +777,7 @@ describe("state/zip.ts", () => {
       expect(walkCalls.length).to.equal(bodyLayers.length);
 
       const expectedFileName = getItemFileName(
+        defaultCatalog,
         "body",
         "light",
         "Body color (light)",
@@ -789,7 +804,7 @@ describe("state/zip.ts", () => {
     it("writes metadata.json with standardAnimations.exported / failed maps per animation (walk only in fixture)", async () => {
       const renderStub = sandbox.stub().resolves(nonEmptyAnimCanvas());
 
-      await exportSplitItemAnimations({
+      await exportSplitItemAnimations(defaultCatalog, {
         renderSingleItemAnimation: renderStub,
       });
 
@@ -803,6 +818,7 @@ describe("state/zip.ts", () => {
         true,
       )._unsafeUnwrap();
       const expectedFileName = getItemFileName(
+        defaultCatalog,
         "body",
         "light",
         "Body color (light)",
@@ -819,7 +835,7 @@ describe("state/zip.ts", () => {
     it("noExport: does not create standard/<anim>/ trees for animations marked noExport (e.g. watering, 1h_slash)", async () => {
       const renderStub = sandbox.stub().resolves(nonEmptyAnimCanvas());
 
-      await exportSplitItemAnimations({
+      await exportSplitItemAnimations(defaultCatalog, {
         renderSingleItemAnimation: renderStub,
       });
 
@@ -832,7 +848,7 @@ describe("state/zip.ts", () => {
     it("includes character.json, credits credits.txt/credits.csv, and credits/metadata.json", async () => {
       const renderStub = sandbox.stub().resolves(nonEmptyAnimCanvas());
 
-      await exportSplitItemAnimations({
+      await exportSplitItemAnimations(defaultCatalog, {
         renderSingleItemAnimation: renderStub,
       });
 
@@ -869,7 +885,7 @@ describe("state/zip.ts", () => {
       const loadImageStub = sandbox.stub().resolves(nonEmptyAnimCanvas());
 
       await renderCharacter(defaultCatalog, state.selections, "male");
-      await exportSplitItemAnimations({
+      await exportSplitItemAnimations(defaultCatalog, {
         loadImage: loadImageStub,
       });
 
@@ -908,7 +924,7 @@ describe("state/zip.ts", () => {
 
       const renderStub = sandbox.stub().resolves(nonEmptyAnimCanvas());
 
-      await exportSplitItemAnimations({
+      await exportSplitItemAnimations(defaultCatalog, {
         renderSingleItemAnimation: renderStub,
       });
 
@@ -923,12 +939,14 @@ describe("state/zip.ts", () => {
         true,
       )._unsafeUnwrap();
       const bodyFileName = getItemFileName(
+        defaultCatalog,
         "body",
         "light",
         "Body color (light)",
         bodyLayers[0].layerNum,
       );
       const headFileName = getItemFileName(
+        defaultCatalog,
         "heads_human_male",
         "light",
         "Human male (light)",
@@ -987,7 +1005,7 @@ describe("state/zip.ts", () => {
       );
 
       await renderCharacter(defaultCatalog, state.selections, "male");
-      await exportSplitItemAnimations({
+      await exportSplitItemAnimations(defaultCatalog, {
         loadImage: loadImageStub,
         addAnimationSliceToZip: addAnimationSliceToZipSpy,
         addStandardAnimationToZipCustomFolder:
@@ -1032,18 +1050,21 @@ describe("state/zip.ts", () => {
 
       const expectedFileNames = {
         body: getItemFileName(
+          defaultCatalog,
           "body",
           "light",
           "Body Color (light)",
           bodyLayers[0].layerNum,
         ),
         head: getItemFileName(
+          defaultCatalog,
           "heads_human_male",
           "light",
           "Human Male (light)",
           headLayers[0].layerNum,
         ),
         weapon: getItemFileName(
+          defaultCatalog,
           "longsword",
           "longsword",
           "Longsword (longsword)",
@@ -1098,7 +1119,7 @@ describe("state/zip.ts", () => {
       );
 
       await renderCharacter(defaultCatalog, state.selections, "male");
-      await exportSplitItemAnimations({
+      await exportSplitItemAnimations(defaultCatalog, {
         loadImage: loadImageStub,
         getImageToDraw: getImageToDrawStub,
         addAnimationSliceToZip: addAnimationSliceToZipSpy,
@@ -1155,7 +1176,7 @@ describe("state/zip.ts", () => {
         const renderStub = sandbox.stub().resolves(nonEmptyAnimCanvas());
         const addSpy = sinon.spy(addCanvasToZip);
 
-        await exportSplitItemAnimations({
+        await exportSplitItemAnimations(defaultCatalog, {
           renderSingleItemAnimation: renderStub,
           addCanvasToZip: addSpy,
         });
@@ -1246,7 +1267,7 @@ describe("state/zip.ts", () => {
         return { up: [{ canvas: fc, frameNumber: 0 }] };
       });
 
-      await exportIndividualFrames({
+      await exportIndividualFrames(defaultCatalog, {
         extractAnimationFromCanvas: extractStub,
         extractFramesFromAnimation: framesSpy,
       });
@@ -1265,7 +1286,7 @@ describe("state/zip.ts", () => {
       const extractStub = sandbox.stub().callsFake(() => smallAnimCanvas());
       const framesFake = sinon.spy(() => ({}));
 
-      await exportIndividualFrames({
+      await exportIndividualFrames(defaultCatalog, {
         extractAnimationFromCanvas: extractStub,
         extractFramesFromAnimation: framesFake,
       });
@@ -1289,7 +1310,7 @@ describe("state/zip.ts", () => {
       });
       const framesFake = sinon.spy(() => ({}));
 
-      await exportIndividualFrames({
+      await exportIndividualFrames(defaultCatalog, {
         extractAnimationFromCanvas: extractStub,
         extractFramesFromAnimation: framesFake,
       });
@@ -1318,7 +1339,7 @@ describe("state/zip.ts", () => {
         return { up: [{ canvas: fc, frameNumber: 0 }] };
       });
 
-      await exportIndividualFrames({
+      await exportIndividualFrames(defaultCatalog, {
         extractAnimationFromCanvas: extractStub,
         extractFramesFromAnimation: framesSpy,
       });
@@ -1331,7 +1352,7 @@ describe("state/zip.ts", () => {
       const extractStub = sandbox.stub().callsFake(() => smallAnimCanvas());
       const framesFake = sinon.spy(() => ({}));
 
-      await exportIndividualFrames({
+      await exportIndividualFrames(defaultCatalog, {
         extractAnimationFromCanvas: extractStub,
         extractFramesFromAnimation: framesFake,
       });
@@ -1370,7 +1391,7 @@ describe("state/zip.ts", () => {
         up: [{ canvas: frameCanvas(), frameNumber: 1 }],
       }));
 
-      await exportIndividualFrames({
+      await exportIndividualFrames(defaultCatalog, {
         extractAnimationFromCanvas: extractStub,
         extractFramesFromAnimation: framesStub,
         extractFramesFromCustomAnimation: extractCustomStub,

--- a/tests/utils/fileName_spec.js
+++ b/tests/utils/fileName_spec.js
@@ -1,16 +1,15 @@
 import { expect } from "chai";
-import { describe, it, beforeEach, afterEach } from "mocha-globals";
-import { resetCatalogForTests } from "../../sources/state/catalog.ts";
-import {
-  restoreAppCatalogAfterTest,
-  seedBrowserCatalog,
-} from "../browser-catalog-fixture.js";
+import { describe, it, beforeEach } from "mocha-globals";
+import { createCatalog } from "../../sources/state/catalog.ts";
+import { seedCatalog } from "../browser-catalog-fixture.js";
 import { getItemFileName } from "../../sources/utils/fileName.ts";
 
 describe("getItemFileName", () => {
+  let catalog;
+
   beforeEach(() => {
-    resetCatalogForTests();
-    seedBrowserCatalog({
+    catalog = createCatalog();
+    seedCatalog(catalog, {
       1: {
         layers: {
           layer_1: { zPos: 50 },
@@ -25,58 +24,60 @@ describe("getItemFileName", () => {
     });
   });
 
-  afterEach(async () => {
-    await restoreAppCatalogAfterTest();
-  });
-
   it("should return the correct filename with zPos prefix", () => {
-    const result = getItemFileName(1, "variant1", "body_male_light");
+    const result = getItemFileName(catalog, 1, "variant1", "body_male_light");
     expect(result).to.equal("050 body_male_light.png");
   });
 
   it("should handle missing metadata and return the name as is", () => {
-    const result = getItemFileName(999, "variant1", "body_male_light");
+    const result = getItemFileName(catalog, 999, "variant1", "body_male_light");
     expect(result).to.equal("body_male_light.png");
   });
 
   it("should throw an error if the requested layer number is not found", () => {
-    expect(() => getItemFileName(1, "variant1", "body_male_light", 3)).to.throw(
-      "Requested layer number 3 not found for item: 1",
-    );
+    expect(() =>
+      getItemFileName(catalog, 1, "variant1", "body_male_light", 3),
+    ).to.throw("Requested layer number 3 not found for item: 1");
   });
 
   it("should use the default layerNum if not provided", () => {
-    const result = getItemFileName(2, "variant2", "body_female_light");
+    const result = getItemFileName(catalog, 2, "variant2", "body_female_light");
     expect(result).to.equal("100 body_female_light.png");
   });
 
   it("should use the altName if name is not provided", () => {
-    const result = getItemFileName(1, "variant1", null);
+    const result = getItemFileName(catalog, 1, "variant1", null);
     expect(result).to.equal("050 1_variant1.png");
   });
 
   it("should pad zPos to 3 digits", () => {
-    const result = getItemFileName(1, "variant1", "body_male_light");
+    const result = getItemFileName(catalog, 1, "variant1", "body_male_light");
     expect(result.startsWith("050")).to.be.true;
   });
 
   it("should sanitize the name to replace non-alphanumeric characters with underscores", () => {
-    const result = getItemFileName(1, "variant1", "body male light");
+    const result = getItemFileName(catalog, 1, "variant1", "body male light");
     expect(result).to.equal("050 body_male_light.png");
   });
 
   it("should append .png if the name does not already end with .png", () => {
-    const result = getItemFileName(1, "variant1", "body_male_light");
+    const result = getItemFileName(catalog, 1, "variant1", "body_male_light");
     expect(result.endsWith(".png")).to.be.true;
   });
 
   it("should not append .png if the name already ends with .png", () => {
-    const result = getItemFileName(1, "variant1", "body_male_light.png");
+    const result = getItemFileName(
+      catalog,
+      1,
+      "variant1",
+      "body_male_light.png",
+    );
     expect(result).to.equal("050 body_male_light.png");
   });
 
   it("should replace the zPos prefix if a zOverride is provided", () => {
     const result = getItemFileName(
+      catalog,
       1,
       "variant1",
       "body_male_light.png",
@@ -87,7 +88,13 @@ describe("getItemFileName", () => {
   });
 
   it("should use a different layer number if provided", () => {
-    const result = getItemFileName(1, "variant1", "body_male_light.png", 2);
+    const result = getItemFileName(
+      catalog,
+      1,
+      "variant1",
+      "body_male_light.png",
+      2,
+    );
     expect(result).to.equal("075 body_male_light.png");
   });
 });


### PR DESCRIPTION
## Summary

  - Inject CatalogReader into all ZIP export APIs.
  - Use the supplied catalog for metadata, layers, recoloring, rendering, filename generation, image processing, and credits.
  - Require a catalog in getItemFileName.
  - Pass the component catalog from ZIP download button handlers.
  - Explicitly pass defaultCatalog from transitional ZIP tests, profiling scripts, and issue-382 golden workflows.
  - Isolate filename tests with fresh catalog instances.
  - Update ZIP renderer-stub assertions for the new catalog-first signatures.