### PR TITLE
test: raise recolor-cache Mocha timeout to 5s

### DIFF
--- a/tests/canvas/palette-recolor-cache_spec.ts
+++ b/tests/canvas/palette-recolor-cache_spec.ts
@@ -76,7 +76,8 @@ describe("canvas/palette-recolor.ts recolor cache", () => {
     });
   });
 
-  it("produces different canvases when recolors differ", async () => {
+  it("produces different canvases when recolors differ", async function () {
+    this.timeout(5_000);
     const img = solidCanvas(255, 0, 0);
     const path = "spritesheets/body/bodies/male/walk.png";
 

--- a/tests/mocha-globals.d.ts
+++ b/tests/mocha-globals.d.ts
@@ -1,14 +1,16 @@
 /** Vite alias target is `tests/bdd-globals.js` (untyped globals). */
 declare module "mocha-globals" {
   type Done = (err?: unknown) => void;
-  type Func = (this: { skip: () => void }, done?: Done) => void;
-  type AsyncFunc = (this: { skip: () => void }) => PromiseLike<unknown>;
+  type TestContext = { skip: () => void; timeout: (ms: number) => void };
+  type Func = (this: TestContext, done?: Done) => void;
+  type AsyncFunc = (this: TestContext) => PromiseLike<unknown>;
 
   export function describe(
     title: string,
     fn: (this: { timeout: (ms: number) => void }) => void,
   ): void;
-  export function it(title: string, fn?: Func | AsyncFunc): void;
+  export function it(title: string, fn?: Func): void;
+  export function it(title: string, fn?: AsyncFunc): void;
   export function before(fn: Func | AsyncFunc): void;
   export function after(fn: Func | AsyncFunc): void;
   export function beforeEach(fn: Func | AsyncFunc): void;


### PR DESCRIPTION
## Summary
- Firefox WebGL recolor can exceed Mocha's 2s default, which flakes **Test browsers** (seen on #577: `produces different canvases when recolors differ` timed out at 3410ms while Chrome passed in 515ms).
- Raise that spec's timeout to 5s and type `this.timeout` on `it` callbacks in `mocha-globals`.

## Test plan
- [x] Confirm **Test browsers** is green on this PR (Firefox + Chrome).
- [x] Optionally re-run #577 after this lands if that Dependabot bump is still red on the same flake.


Made with [Cursor](https://cursor.com)